### PR TITLE
expose console on cli object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,4 @@
+var console = require('./console');
 var errors = require('./errors');
 
 exports.run = require('./run');
@@ -6,3 +7,4 @@ exports.formatDate = require('./date').formatDate;
 exports.error = errors.error;
 exports.warn = errors.warn;
 exports.columnify = require('./columnify');
+exports.console = console;


### PR DESCRIPTION
exposes the console so plugins can use `mock` in their tests too:

```js
var cli = require('heroku-cli-util');
cli.console.mock();
// plugin tests here will be able to inspect stdout/stderr without invading test results
```
