### PR TITLE
bind exposed console

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@ var console = require('./console');
 var errors = require('./errors');
 
 exports.run = require('./run');
-exports.log = console.log;
+exports.log = console.log.bind(console);
 exports.formatDate = require('./date').formatDate;
 exports.error = errors.error;
 exports.warn = errors.warn;


### PR DESCRIPTION
@dickeyxxx `errors` already closes over console, but I missed it on `log`