### PR TITLE
remove co, switch to bluebird.coroutine in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,18 +178,19 @@ It expects you to return a promise chain. This is usually done with [co](https:/
 ```js
 let cli = require('heroku-cli-util');
 let co  = require('co');
+
+function* run (context, heroku) {
+  let app = yield heroku.apps(context.app).info();
+  console.dir(app);
+}
+
 module.exports.commands = [
   {
     topic: 'apps',
     command: 'info',
     needsAuth: true,
     needsApp: true,
-    run: cli.command(function (context, heroku) {
-      return co(function* () {
-        let app = yield heroku.apps(context.app).info();
-        console.dir(app);
-      });
-    })
+    run: cli.command(co.wrap(run))
   }
 ];
 ```
@@ -199,21 +200,19 @@ With options:
 ```js
 let cli = require('heroku-cli-util');
 let co  = require('co');
+
+function* run (heroku, context) {
+  let app = yield heroku.apps(context.app).info();
+  console.dir(app);
+}
+
 module.exports.commands = [
   {
     topic: 'apps',
     command: 'info',
     needsAuth: true,
     needsApp: true,
-    run: cli.command(
-      {preauth: true},
-      function (context, heroku) {
-        return co(function* () {
-          let app = yield heroku.apps(context.app).info();
-          console.dir(app);
-        });
-      }
-    )
+    run: cli.command({preauth: true}, co.wrap(run))
   }
 ];
 ```

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,6 +1,5 @@
 'use strict';
 
-let co      = require('co');
 let Heroku  = require('heroku-client');
 let cli     = require('..');
 let url     = require('url');
@@ -56,7 +55,7 @@ module.exports = function command (options, fn) {
     cli.color.enabled = context.supportsColor;
     let handleErr = cli.errorHandler(errHandlerOpts(options.rollbar, context));
     let run = function () {
-      return co.wrap(fn)(context, heroku(context))
+      return fn(context, heroku(context))
       .catch(function (err) {
         if (err && err.body && err.body.id === 'two_factor') {
           cli.prompt('Two-factor code', {mask: true})

--- a/package.json
+++ b/package.json
@@ -22,14 +22,12 @@
     "nock": "^2.6.0"
   },
   "dependencies": {
-    "chalk": "^1.1.0",
-    "co": "^4.5.4",
-    "heroku-client": "^2.1.0",
-    "inflection": "^1.7.1"
+    "chalk": "1.1.1",
+    "heroku-client": "2.1.0",
+    "inflection": "1.7.1"
   },
   "bundledDependencies": [
     "chalk",
-    "co",
     "heroku-client",
     "inflection"
   ]

--- a/test/preauth.js
+++ b/test/preauth.js
@@ -6,12 +6,13 @@ let nock   = require('nock');
 describe('preauth', function () {
   it('makes a POST to /apps/myapp/pre-authorizations', function () {
     let heroku = new Heroku();
-    nock('https://api.heroku.com', {
+    let http = nock('https://api.heroku.com', {
       reqheaders: {'Heroku-Two-Factor-Code': '2fa key'}
     })
     .put('/apps/myapp/pre-authorizations')
     .reply(200, {});
 
-    return cli.preauth('myapp', heroku, '2fa key');
+    return cli.preauth('myapp', heroku, '2fa key')
+    .then(() => http.done());
   });
 });


### PR DESCRIPTION
this should now be used in the plugin only and not depending on co
automatically being run. I'm also now recommending bluebird.coroutine
over co (which is nearly equivalent, but a bit more pure)

this will require a major bump