### PR TITLE
variations on a header

### DIFF
--- a/lib/styled.js
+++ b/lib/styled.js
@@ -14,7 +14,7 @@ let inflection = require('inflection');
  * @returns {null}
  */
 function styledHeader(header) {
-  cli.log(`=== ${header}`);
+  cli.log(cli.color.gray('=== ') + cli.color.bold(header));
 }
 
 /**


### PR DESCRIPTION
current:

<img width="804" alt="screen shot 2015-10-30 at 11 00 23 am" src="https://cloud.githubusercontent.com/assets/216188/10853857/ac68c2d6-7ef5-11e5-90d0-c33251b05bb5.png">

dull header:

<img width="825" alt="screen shot 2015-10-30 at 11 00 33 am" src="https://cloud.githubusercontent.com/assets/216188/10853868/b5e2f426-7ef5-11e5-9f73-b336515ee17f.png">

dull equals + bold header:

<img width="804" alt="screen shot 2015-10-30 at 11 00 10 am" src="https://cloud.githubusercontent.com/assets/216188/10853876/c02313da-7ef5-11e5-8fd4-64d8e55429a9.png">

Another example:

<img width="644" alt="screen shot 2015-10-30 at 11 10 24 am" src="https://cloud.githubusercontent.com/assets/216188/10854080/cfe312c4-7ef6-11e5-829a-1411981ca830.png">

