### PR TITLE
Fixing join character in mock from , to space

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -7,7 +7,7 @@ var mocking;
 function concatArguments(args) {
   return Array.prototype.map.call(args, function(arg) {
     return arg + '';
-  }).join();
+  }).join(' ');
 }
 
 /**


### PR DESCRIPTION
> cli.log(undefined, undefined)
undefined undefined
> cli.mockConsole()
> cli.log(undefined, undefined)
> cli.stdout
'undefined,undefined\n'