### PR TITLE
trim table trailing spaces

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -10,7 +10,7 @@ let defaults = {
     headerAnsi: _.identity,
     printLine:  cli.log,
     printRow:   function(cells) {
-        this.printLine(cells.join(this.colSep));
+        this.printLine(cells.join(this.colSep).trimRight());
     },
     printHeader: function(cells) {
         this.printRow(cells.map(_.ary(this.headerAnsi, 1)));


### PR DESCRIPTION
This won't visibly change the output but it will remove trailing spaces
at the end of the table output. These spaces throw off `wc` numbers and
require adding trailing spaces to some of the tests.