### PR TITLE
add styled name values

### DIFF
--- a/lib/styled.js
+++ b/lib/styled.js
@@ -59,5 +59,50 @@ function styledObject(obj, keys) {
   }
 }
 
+/**
+ * styledNameValues logs an array of {name: '', values: ['']} objects in a consistent style
+ *
+ * @example
+ * styledNameValues([{name: "Collaborators", values: ["user1@example.com", "user2@example.com"]},
+ *               {name: "Name", values: ["myapp"]}])
+ * Collaborators: user1@example.com
+ *                user2@example.com
+ * Name:          myapp
+ *
+ * @param {nameValues} nameValues
+ * @returns {null}
+ */
+function styledNameValues(nameValues) {
+  let keys = nameValues.map(function(nameValue) { return nameValue.name; });
+  let keyLengths = keys.map(function(name) { return name.toString().length; });
+  let maxKeyLength = Math.max.apply(Math, keyLengths) + 2;
+  function pp(obj) {
+    if (typeof obj === 'string' || typeof obj === 'number') {
+      return obj;
+    } else if (typeof obj === 'object') {
+      return Object.keys(obj).map(k => k + ': ' + cli.inspect(obj[k])).join(', ');
+    } else {
+      return cli.inspect(obj);
+    }
+  }
+  function logKeyValue(key, value) {
+    cli.log(`${key}:`+' '.repeat(maxKeyLength - key.length-1)+pp(value));
+  }
+  for (var nameValue of nameValues) {
+    let value = nameValue.values;
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        logKeyValue(nameValue.name, value[0]);
+        for (var e of value.slice(1)) {
+          cli.log(" ".repeat(maxKeyLength) + pp(e));
+        }
+      }
+    } else if (value !== null && value !== undefined) {
+      logKeyValue(nameValue.name, value);
+    }
+  }
+}
+
 module.exports.styledHeader = styledHeader;
 module.exports.styledObject = styledObject;
+module.exports.styledNameValues = styledNameValues;

--- a/test/styled.js
+++ b/test/styled.js
@@ -15,3 +15,17 @@ describe('styledHash', function () {
     expect(cli.color.stripColor(cli.stdout)).to.contain('=== MyApp\n');
   });
 });
+
+describe('styledNameValues', function () {
+  it('prints out a styled set of name values', function () {
+    cli.styledHash([{name: 'Name', values: ["myapp"]}, {name: 'Collaborators', values: ["user1@example.com", "user2@example.com"]}]);
+    expect(cli.color.stripColor(cli.stdout)).to.contain('Collaborators: user1@example.com\n' +
+     '               user2@example.com\n' +
+     'Name:          myapp\n');
+  });
+
+  it('prints out a styled header', function () {
+    cli.styledHeader('MyApp');
+    expect(cli.color.stripColor(cli.stdout)).to.contain('=== MyApp\n');
+  });
+});


### PR DESCRIPTION
nearly all the DoD plugins want to use this kind of output. Using
styledHash and converting from the format here works somewhat ok,
buuuuut breaks down if you want to e.g. have duplicate keys.

For example, here's the current (broken) output of `heroku
cassandra:info`:

```bash
=== CASSANDRA_URL
Name:        cassandra-hi-jeff-5562
Created:     2015-09-42 09:42 UTC
Plan:        Alpha Medium
Status:      available
Connections: 368
Tables:      9001
Data Size:   1.35 PB

== Reads:
Throughput:  849.37
Latency:     50th 0.24ms
             95th 0.24ms
             99th 0.92ms

== Writes:
Throughput:  849.37
Latency:     50th 0.24ms
             95th 0.24ms
             99th 0.92ms
```

The duplicated "throughput" and latency columns happen because `styledHash`
doesn't allow for keys with the same name.