### PR TITLE
remove prepending warnings with WARNING:

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 5.0.0
+    version: 5.7.1

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -50,7 +50,7 @@ function error (err) {
 }
 
 function warn (msg) {
-  console.error(bangify(wrap(`WARNING: ${msg}`), cli.color.yellow(arrow)));
+  console.error(bangify(wrap(msg), cli.color.yellow(arrow)));
 }
 
 function logtimestamp() {

--- a/test/errors.js
+++ b/test/errors.js
@@ -12,6 +12,6 @@ describe('errors', function () {
 
   it('prints out warnings', function () {
     cli.warn('foobar');
-    expect(cli.color.stripColor(cli.stderr)).to.equal(' ▸    WARNING: foobar\n');
+    expect(cli.color.stripColor(cli.stderr)).to.equal(' ▸    foobar\n');
   });
 });


### PR DESCRIPTION
this has been getting in the way more than it has been helping. For
example, cli.confirmApp() is pretty broken looking because of it.

I still don't like that without colors warnings look like errors, but
we'll have to find a different solution to that problem.

For example:
```
$ heroku redis:cli -a heroku-npm
 ▸    WARNING: WARNING: Insecure action.
 ▸    All data, including the Redis password, will not be encrypted.
 ▸    WARNING: To proceed, type heroku-npm or re-run this command with --confirm heroku-npm
```