### PR TITLE
fix wrapping with command examples

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,7 +12,8 @@ function errtermwidth() {
 function wrap (msg) {
   return linewrap(6,
     errtermwidth(), {
-    skipScheme: 'ansi-color'
+    skipScheme: 'ansi-color',
+    skip: /^\$ .*$/,
   })(msg || '');
 }
 


### PR DESCRIPTION
turns this:

```
▸    To drain to splunk do the following:
▸    $ heroku drains:add -a heroku-npm https://$(foo > /dev/null; foo-client
▸    MAP | awk -F '|' {print
▸    $2}')@logs.foo.com/logs
```

into this:

```
▸    To drain to splunk do the following:
▸    $ heroku drains:add -a heroku-npm https://$(foo > /dev/null; foo-client MAP | awk -F '|' {print $2}')@logs.foo.com/logs
```