### PR TITLE
Replace rollbar https client with got client

### DIFF
--- a/lib/rollbar.js
+++ b/lib/rollbar.js
@@ -3,35 +3,12 @@
 const GLOBAL_CRED = 'b66ca6f60fe049d6bedfe3e2ccb28d8c'
 const ROLLBAR_URL = 'https://api.rollbar.com/api/1/item/'
 
-function concat (stream, callback) {
-  var strings = []
-  stream.on('data', function (data) {
-    strings.push(data)
-  })
-  stream.on('end', function () {
-    callback(strings.join(''))
-  })
-}
-
 function request (method, url, payload) {
-  const https = require('https')
-  const parseUrl = require('url').parse
+  const got = require('./got')
 
-  return new Promise(function (resolve, reject) {
-    let body = JSON.stringify(payload)
-    url = parseUrl(url)
-    let req = https.request({
-      hostname: url.hostname,
-      path: url.path,
-      method: method
-    }, function (res) {
-      concat(res, function (data) {
-        if (res.statusCode >= 200 && res.statusCode < 300) resolve(data)
-        else reject(data)
-      })
-    })
-    req.setHeader('Content-Length', Buffer.byteLength(body))
-    req.write(body)
+  return got(url, {
+    method: method,
+    body: JSON.stringify(payload)
   })
 }
 


### PR DESCRIPTION
This fixes a bug where the rollbar client does not properly use the HTTPS_PROXY variables