### PR TITLE
Note that cli.confirmApp needs a confirm flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ yield cli.confirmApp('appname', context.flags.confirm, 'foo');
 > appname
 ```
 
+Note that you will still need to define a `confirm` flag for your command.
+
 ## Errors
 
 ```js


### PR DESCRIPTION
This wasn't clear to me and [I broke --confirm in our Kafka plugin](https://github.com/heroku/heroku-kafka-jsplugin/pull/67).