### PR TITLE
add quiet mode for cli.prompt

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ exports.command = require('./lib/command')
 exports.color = require('./lib/color')
 exports.debug = console.debug
 exports.mockConsole = console.mock
+exports.mockPrompt = prompt.mock
 exports.table = require('./lib/table')
 exports.stdout = ''
 exports.stderr = ''

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ exports.command = require('./lib/command')
 exports.color = require('./lib/color')
 exports.debug = console.debug
 exports.mockConsole = console.mock
-exports.mockPrompt = prompt.mock
 exports.table = require('./lib/table')
 exports.stdout = ''
 exports.stderr = ''

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -128,11 +128,5 @@ This command will affect the app ${cli.color.bold.red(app)}`
   })
 }
 
-/**
- * mock will make {@link log} and {@link error}
- * stop printing to stdout and stderr and start writing to the
- * stdout and stderr strings.
- */
-
 exports.prompt = util.promiseOrCallback(prompt)
 exports.confirmApp = util.promiseOrCallback(confirmApp)

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -80,11 +80,14 @@ function prompt (name, options) {
   options = options || {}
   options.name = name
   options.prompt = name ? color.gray(`${name}: `) : color.gray('> ')
+  options.quiet = options.quiet || false
   let isTTY = process.env.TERM !== 'dumb' && process.stdin.isTTY
   if (isTTY && (options.mask || options.hide)) return promptMasked(options)
   return new Promise(function (resolve) {
     process.stdin.setEncoding('utf8')
-    process.stderr.write(options.prompt)
+    if (!options.quiet) {
+      process.stderr.write(options.prompt)
+    }
     process.stdin.resume()
     process.stdin.once('data', function (data) {
       process.stdin.pause()

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -6,8 +6,6 @@ const util = require('./util')
 const color = require('./color')
 const ansi = require('ansi-escapes')
 
-var mocking
-
 function promptMasked (options) {
   return new Promise(function (resolve, reject) {
     let stdin = process.stdin
@@ -16,7 +14,7 @@ function promptMasked (options) {
     stdin.setEncoding('utf8')
     stderr.write(ansi.eraseLine)
     stderr.write(ansi.cursorLeft)
-    if (mocking) {
+    if (cli.console.mocking()) {
       cli.stderr += cli.color.stripColor(options.prompt)
     } else {
       stderr.write(options.prompt)
@@ -90,7 +88,7 @@ function prompt (name, options) {
   if (isTTY && (options.mask || options.hide)) return promptMasked(options)
   return new Promise(function (resolve) {
     process.stdin.setEncoding('utf8')
-    if (mocking) {
+    if (cli.console.mocking()) {
       cli.stderr += cli.color.stripColor(options.prompt)
     } else {
       process.stderr.write(options.prompt)
@@ -136,18 +134,5 @@ This command will affect the app ${cli.color.bold.red(app)}`
  * stdout and stderr strings.
  */
 
-// copied from console
-function mock (mock) {
-  if (mock === false) {
-    mocking = false
-  } else {
-    mocking = true
-    cli.stderr = ''
-    cli.stdout = ''
-  }
-}
-
 exports.prompt = util.promiseOrCallback(prompt)
 exports.confirmApp = util.promiseOrCallback(confirmApp)
-exports.mock = mock
-exports.mocking = () => mocking

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -6,6 +6,8 @@ const util = require('./util')
 const color = require('./color')
 const ansi = require('ansi-escapes')
 
+var mocking
+
 function promptMasked (options) {
   return new Promise(function (resolve, reject) {
     let stdin = process.stdin
@@ -14,7 +16,11 @@ function promptMasked (options) {
     stdin.setEncoding('utf8')
     stderr.write(ansi.eraseLine)
     stderr.write(ansi.cursorLeft)
-    stderr.write(options.prompt)
+    if (mocking) {
+      cli.stderr += cli.color.stripColor(options.prompt)
+    } else {
+      stderr.write(options.prompt)
+    }
     stdin.resume()
     stdin.setRawMode(true)
 
@@ -80,12 +86,13 @@ function prompt (name, options) {
   options = options || {}
   options.name = name
   options.prompt = name ? color.gray(`${name}: `) : color.gray('> ')
-  options.quiet = options.quiet || false
   let isTTY = process.env.TERM !== 'dumb' && process.stdin.isTTY
   if (isTTY && (options.mask || options.hide)) return promptMasked(options)
   return new Promise(function (resolve) {
     process.stdin.setEncoding('utf8')
-    if (!options.quiet) {
+    if (mocking) {
+      cli.stderr += cli.color.stripColor(options.prompt)
+    } else {
       process.stderr.write(options.prompt)
     }
     process.stdin.resume()
@@ -123,5 +130,24 @@ This command will affect the app ${cli.color.bold.red(app)}`
   })
 }
 
+/**
+ * mock will make {@link log} and {@link error}
+ * stop printing to stdout and stderr and start writing to the
+ * stdout and stderr strings.
+ */
+
+// copied from console
+function mock (mock) {
+  if (mock === false) {
+    mocking = false
+  } else {
+    mocking = true
+    cli.stderr = ''
+    cli.stdout = ''
+  }
+}
+
 exports.prompt = util.promiseOrCallback(prompt)
 exports.confirmApp = util.promiseOrCallback(confirmApp)
+exports.mock = mock
+exports.mocking = () => mocking

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -14,11 +14,7 @@ function promptMasked (options) {
     stdin.setEncoding('utf8')
     stderr.write(ansi.eraseLine)
     stderr.write(ansi.cursorLeft)
-    if (cli.console.mocking()) {
-      cli.stderr += cli.color.stripColor(options.prompt)
-    } else {
-      stderr.write(options.prompt)
-    }
+    cli.console.writeError(options.prompt)
     stdin.resume()
     stdin.setRawMode(true)
 
@@ -88,11 +84,7 @@ function prompt (name, options) {
   if (isTTY && (options.mask || options.hide)) return promptMasked(options)
   return new Promise(function (resolve) {
     process.stdin.setEncoding('utf8')
-    if (cli.console.mocking()) {
-      cli.stderr += cli.color.stripColor(options.prompt)
-    } else {
-      process.stderr.write(options.prompt)
-    }
+    cli.console.writeError(options.prompt)
     process.stdin.resume()
     process.stdin.once('data', function (data) {
       process.stdin.pause()


### PR DESCRIPTION
For tests, results get really noisy when prompts output every time. Instead of messing with stderr (also, why does `cli.prompt` use stderr?), adding an option seems like a more straightforward solution. 