### PR TITLE
Add a new color definition for pipelines

### DIFF
--- a/lib/color.js
+++ b/lib/color.js
@@ -15,6 +15,7 @@ for (let color of Object.keys(colors)) {
 
 colors.release = s => chalk.blue.bold(s)
 colors.cmd = s => chalk.cyan.bold(s)
+colors.pipeline = s => chalk.green.bold(s)
 
 colors.heroku = s => {
   if (!chalk.enabled) return s


### PR DESCRIPTION
I was updating the [heroku-pipelines](https://github.com/heroku/heroku-pipelines) to make use of the standard color definition for apps, and then I realized that instead of coming with a color to also indicate pipelines, it'd be nice to standardize it in case other plugins want to make use of it.

Does this work for you guys? @dickeyxxx @ransombriggs 