### PR TITLE
Retry just the request when 2fa / preauth

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -5,14 +5,79 @@ const cli = require('..')
 const auth = require('./auth')
 const vars = require('./vars')
 
-function apiMiddleware (response, cb) {
-  let warning = response.headers['x-heroku-warning'] || response.headers['warning-message']
-  if (warning) cli.action.warn(warning)
-  cb()
+function twoFactorWrapper (options, preauths, context) {
+  return function (res, buffer) {
+    let body
+    try {
+      body = this.parseBody(buffer)
+    } catch (e) {
+      this._handleFailure(res, buffer)
+    }
+
+    // safety check for if we have already seen this request for preauthing
+    // this prevents an infinite loop in case some preauth fails silently
+    // and we continue to get two_factor failures
+
+    // this might be better done with a timer in case a command takes too long
+    // and the preauthorization runs out, but that seemed unlikely
+    if (res.statusCode === 403 && body.id === 'two_factor' && !preauths.requests.includes(this)) {
+      let self = this
+      twoFactorPrompt(options, context)
+      .then(function (secondFactor) {
+        // default preauth to always happen unless explicitly disabled
+        if (options.preauth === false) {
+          self.options.headers = Object.assign({}, self.options.headers, {'Heroku-Two-Factor-Code': secondFactor})
+          self.request()
+        } else {
+          preauths.requests.push(self)
+
+          // if multiple requests are run in parallel for the same app, we should
+          // only preauth for the first so save the fact we already preauthed
+          if (!preauths.promises[body.app.name]) {
+            preauths.promises[body.app.name] = cli.preauth(body.app.name, heroku(context), secondFactor)
+          }
+
+          preauths.promises[body.app.name].then(function () {
+            self.request()
+          })
+          .catch(function (err) {
+            self.reject(err)
+          })
+        }
+      })
+      .catch(function (err) {
+        self.reject(err)
+      })
+    } else {
+      this._handleFailure(res, buffer)
+    }
+  }
 }
 
-function heroku (context) {
+function apiMiddleware (options, preauths, context) {
+  let twoFactor = twoFactorWrapper(options, preauths, context)
+  return function (response, cb) {
+    let warning = response.headers['x-heroku-warning'] || response.headers['warning-message']
+    if (warning) cli.action.warn(warning)
+
+    // override the _handleFailure for this request
+    if (!this._handleFailure) {
+      this._handleFailure = this.handleFailure
+      this.handleFailure = twoFactor.bind(this)
+    }
+
+    cb()
+  }
+}
+
+function heroku (context, options) {
   let host = context.apiUrl || vars.apiUrl || 'https://api.heroku.com'
+
+  let preauths = {
+    promises: {},
+    requests: []
+  }
+
   let opts = {
     userAgent: context.version,
     debug: context.debug,
@@ -21,7 +86,7 @@ function heroku (context) {
     host: host,
     headers: {},
     rejectUnauthorized: !(process.env.HEROKU_SSL_VERIFY === 'disable' || host.endsWith('herokudev.com')),
-    middleware: apiMiddleware
+    middleware: apiMiddleware(options, preauths, context)
   }
   if (process.env.HEROKU_HEADERS) {
     Object.assign(opts.headers, JSON.parse(process.env.HEROKU_HEADERS))
@@ -59,16 +124,13 @@ Ensure this is set to a correct value or unset it to use the netrc file.`)
 function twoFactorPrompt (options, context) {
   cli.yubikey.enable()
   return cli.prompt('Two-factor code', {mask: true})
+    .catch(function (err) {
+      cli.yubikey.disable()
+      throw err
+    })
     .then(function (secondFactor) {
       cli.yubikey.disable()
       return secondFactor
-    })
-    .then(function (secondFactor) {
-      if (options.preauth) {
-        return cli.preauth(context.app, heroku(context), secondFactor)
-      } else {
-        context.secondFactor = secondFactor
-      }
     })
 }
 
@@ -87,7 +149,7 @@ module.exports = function command (options, fn) {
     let handleErr = cli.errorHandler({debug: context.debug})
     let run = function () {
       context.auth = {password: auth.token()}
-      let p = fn(context, heroku(context))
+      let p = fn(context, heroku(context, options))
       if (!p.catch) return
       return p.catch(function (err) {
         if (err && err.body && err.body.id === 'unauthorized') {
@@ -96,8 +158,6 @@ module.exports = function command (options, fn) {
         } else if (err && err.body && err.body.id === 'sudo_reason_required') {
           cli.warn(err.body.message)
           reasonPrompt(context).then(run).catch(handleErr)
-        } else if (err && err.body && err.body.id === 'two_factor') {
-          twoFactorPrompt(options, context).then(run).catch(handleErr)
         } else throw err
       }).catch(handleErr)
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -4,6 +4,7 @@ const Heroku = require('heroku-client')
 const cli = require('..')
 const auth = require('./auth')
 const vars = require('./vars')
+const Mutex = require('./mutex')
 
 function twoFactorWrapper (options, preauths, context) {
   return function (res, buffer) {
@@ -22,32 +23,35 @@ function twoFactorWrapper (options, preauths, context) {
     // and the preauthorization runs out, but that seemed unlikely
     if (res.statusCode === 403 && body.id === 'two_factor' && !preauths.requests.includes(this)) {
       let self = this
-      twoFactorPrompt(options, context)
-      .then(function (secondFactor) {
-        // default preauth to always happen unless explicitly disabled
-        if (options.preauth === false) {
+      // default preauth to always happen unless explicitly disabled
+      if (options.preauth === false) {
+        twoFactorPrompt(options, preauths, context)
+        .then(function (secondFactor) {
           self.options.headers = Object.assign({}, self.options.headers, {'Heroku-Two-Factor-Code': secondFactor})
           self.request()
-        } else {
-          preauths.requests.push(self)
+        })
+        .catch(function (err) {
+          self.reject(err)
+        })
+      } else {
+        preauths.requests.push(self)
 
-          // if multiple requests are run in parallel for the same app, we should
-          // only preauth for the first so save the fact we already preauthed
-          if (!preauths.promises[body.app.name]) {
-            preauths.promises[body.app.name] = cli.preauth(body.app.name, heroku(context), secondFactor)
-          }
-
-          preauths.promises[body.app.name].then(function () {
-            self.request()
-          })
-          .catch(function (err) {
-            self.reject(err)
+        // if multiple requests are run in parallel for the same app, we should
+        // only preauth for the first so save the fact we already preauthed
+        if (!preauths.promises[body.app.name]) {
+          preauths.promises[body.app.name] = twoFactorPrompt(options, preauths, context)
+          .then(function (secondFactor) {
+            return cli.preauth(body.app.name, heroku(context), secondFactor)
           })
         }
-      })
-      .catch(function (err) {
-        self.reject(err)
-      })
+
+        preauths.promises[body.app.name].then(function () {
+          self.request()
+        })
+        .catch(function (err) {
+          self.reject(err)
+        })
+      }
     } else {
       this._handleFailure(res, buffer)
     }
@@ -75,7 +79,8 @@ function heroku (context, options) {
 
   let preauths = {
     promises: {},
-    requests: []
+    requests: [],
+    twoFactorMutex: new Mutex()
   }
 
   let opts = {
@@ -121,9 +126,10 @@ Ensure this is set to a correct value or unset it to use the netrc file.`)
   return auth.login({save: true})
 }
 
-function twoFactorPrompt (options, context) {
+function twoFactorPrompt (options, preauths, context) {
   cli.yubikey.enable()
-  return cli.prompt('Two-factor code', {mask: true})
+  return preauths.twoFactorMutex.synchronize(function () {
+    return cli.prompt('Two-factor code', {mask: true})
     .catch(function (err) {
       cli.yubikey.disable()
       throw err
@@ -132,6 +138,7 @@ function twoFactorPrompt (options, context) {
       cli.yubikey.disable()
       return secondFactor
     })
+  })
 }
 
 function reasonPrompt (context) {

--- a/lib/mutex.js
+++ b/lib/mutex.js
@@ -1,0 +1,41 @@
+'use strict'
+
+// Adapted from https://blog.jcoglan.com/2016/07/12/mutexes-and-javascript/
+
+let Mutex = function () {
+  this._busy = false
+  this._queue = []
+}
+
+Mutex.prototype.synchronize = function (task) {
+  let self = this
+
+  return new Promise(function (resolve, reject) {
+    self._queue.push([task, resolve, reject])
+    if (!self._busy) {
+      self._dequeue()
+    }
+  })
+}
+
+Mutex.prototype._dequeue = function () {
+  this._busy = true
+  let next = this._queue.shift()
+
+  if (next) {
+    this._execute(next)
+  } else {
+    this._busy = false
+  }
+}
+
+Mutex.prototype._execute = function (record) {
+  let [task, resolve, reject] = record
+  let self = this
+
+  task().then(resolve, reject).then(function () {
+    self._dequeue()
+  })
+}
+
+module.exports = Mutex

--- a/test/command.js
+++ b/test/command.js
@@ -1,0 +1,242 @@
+'use strict'
+/* globals describe it beforeEach */
+
+let nock = require('nock')
+let co = require('co')
+let expect = require('unexpected')
+
+let cli = require('..')
+let command = require('../lib/command')
+
+describe('command', function () {
+  beforeEach(function () {
+    nock.disableNetConnect()
+    nock.cleanAll()
+
+    cli.mockConsole()
+    cli.prompt = function () {
+      return new Promise(function (resolve, reject) {
+        resolve('2fa')
+      })
+    }
+  })
+
+  it('2fa should retry just the failing request', function () {
+    let api = nock('https://api.heroku.com')
+
+    api.post('/bizbaz', {}).reply(200, {value: 'bizbaz'})
+
+    api.post('/foobar', {}).reply(403, {'id': 'two_factor'})
+
+    let api2FA = nock('https://api.heroku.com', {
+      reqheaders: {'Heroku-Two-Factor-Code': '2fa'}
+    })
+
+    api2FA.post('/foobar', {}).reply(200, {value: 'foobar'})
+
+    return command({preauth: false}, co.wrap(function * (context, heroku) {
+      let bizbaz = yield heroku.post('/bizbaz', {body: {}})
+      cli.log(bizbaz.value)
+
+      let foobar = yield heroku.post('/foobar', {body: {}})
+      cli.log(foobar.value)
+    }))({})
+    .then(() => {
+      api.done()
+      api2FA.done()
+      expect(cli.stdout, 'to equal', 'bizbaz\nfoobar\n')
+    })
+  })
+
+  it('2fa should preauth then run request again', function () {
+    let api = nock('https://api.heroku.com', {
+      badheaders: ['Heroku-Two-Factor-Code']
+    })
+
+    api.post('/bizbaz', {}).reply(200, {value: 'bizbaz'})
+
+    api.post('/foobar', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'biz'}})
+
+    let api2FA = nock('https://api.heroku.com', {
+      reqheaders: {'Heroku-Two-Factor-Code': '2fa'}
+    })
+
+    api2FA.put('/apps/biz/pre-authorizations').reply(200, {})
+
+    api.post('/foobar', {}).reply(200, {value: 'foobar'})
+
+    return command({preauth: true}, co.wrap(function * (context, heroku) {
+      let bizbaz = yield heroku.post('/bizbaz', {body: {}})
+      cli.log(bizbaz.value)
+
+      let foobar = yield heroku.post('/foobar', {body: {}})
+      cli.log(foobar.value)
+    }))({app: 'fuzz'})
+    .then(() => {
+      api.done()
+      api2FA.done()
+      expect(cli.stdout, 'to equal', 'bizbaz\nfoobar\n')
+    })
+  })
+
+  it('2fa should preauth if options.preauth is undefined', function () {
+    let api = nock('https://api.heroku.com', {
+      badheaders: ['Heroku-Two-Factor-Code']
+    })
+
+    api.post('/bizbaz', {}).reply(200, {value: 'bizbaz'})
+
+    api.post('/foobar', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'biz'}})
+
+    let api2FA = nock('https://api.heroku.com', {
+      reqheaders: {'Heroku-Two-Factor-Code': '2fa'}
+    })
+
+    api2FA.put('/apps/biz/pre-authorizations').reply(200, {})
+
+    api.post('/foobar', {}).reply(200, {value: 'foobar'})
+
+    return command({}, co.wrap(function * (context, heroku) {
+      let bizbaz = yield heroku.post('/bizbaz', {body: {}})
+      cli.log(bizbaz.value)
+
+      let foobar = yield heroku.post('/foobar', {body: {}})
+      cli.log(foobar.value)
+    }))({app: 'fuzz'})
+    .then(() => {
+      api.done()
+      api2FA.done()
+      expect(cli.stdout, 'to equal', 'bizbaz\nfoobar\n')
+    })
+  })
+
+  it('2fa should preauth just one time per app', function () {
+    let api = nock('https://api.heroku.com', {
+      badheaders: ['Heroku-Two-Factor-Code']
+    })
+
+    api.post('/foobar/a', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'biz'}})
+    api.post('/foobar/b', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'biz'}})
+
+    let api2FA = nock('https://api.heroku.com', {
+      reqheaders: {'Heroku-Two-Factor-Code': '2fa'}
+    })
+
+    api2FA.put('/apps/biz/pre-authorizations').reply(200, {})
+
+    api.post('/foobar/a', {}).reply(200, {value: 'foobara'})
+    api.post('/foobar/b', {}).reply(200, {value: 'foobarb'})
+
+    return command({preauth: true}, co.wrap(function * (context, heroku) {
+      let bizbaz = yield [
+        heroku.post('/foobar/a', {body: {}}),
+        heroku.post('/foobar/b', {body: {}})
+      ]
+      bizbaz.forEach((l) => cli.log(l.value))
+    }))({app: 'fuzz'})
+    .then(() => {
+      api.done()
+      api2FA.done()
+      expect(cli.stdout, 'to equal', 'foobara\nfoobarb\n')
+    })
+  })
+
+  it('2fa should preauth for each app', function () {
+    let api = nock('https://api.heroku.com', {
+      badheaders: ['Heroku-Two-Factor-Code']
+    })
+
+    api.post('/foobar/a', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'biz'}})
+    api.post('/foobar/b', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'baz'}})
+
+    let api2FA = nock('https://api.heroku.com', {
+      reqheaders: {'Heroku-Two-Factor-Code': '2fa'}
+    })
+
+    api2FA.put('/apps/biz/pre-authorizations').reply(200, {})
+    api2FA.put('/apps/baz/pre-authorizations').reply(200, {})
+
+    api.post('/foobar/a', {}).reply(200, {value: 'foobara'})
+    api.post('/foobar/b', {}).reply(200, {value: 'foobarb'})
+
+    return command({preauth: true}, co.wrap(function * (context, heroku) {
+      let bizbaz = yield [
+        heroku.post('/foobar/a', {body: {}}),
+        heroku.post('/foobar/b', {body: {}})
+      ]
+      bizbaz.forEach((l) => cli.log(l.value))
+    }))({app: 'fuzz'})
+    .then(() => {
+      api.done()
+      api2FA.done()
+      expect(cli.stdout, 'to equal', 'foobara\nfoobarb\n')
+    })
+  })
+
+  it('preauth should fail if we keep getting two factored for each app', function () {
+    let api = nock('https://api.heroku.com', {
+      badheaders: ['Heroku-Two-Factor-Code']
+    })
+
+    api.post('/foobar/a', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'biz'}})
+    api.post('/foobar/b', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'biz'}})
+
+    let api2FA = nock('https://api.heroku.com', {
+      reqheaders: {'Heroku-Two-Factor-Code': '2fa'}
+    })
+
+    api2FA.put('/apps/biz/pre-authorizations').reply(200, {})
+
+    api.post('/foobar/a', {}).reply(200, {value: 'foobara'})
+    api.post('/foobar/b', {}).reply(403, {'id': 'two_factor', 'app': {'name': 'biz'}})
+
+    return command({preauth: true}, co.wrap(function * (context, heroku) {
+      let bizbaz = yield [
+        heroku.post('/foobar/a', {body: {}}),
+        heroku.post('/foobar/b', {body: {}})
+      ]
+      bizbaz.forEach((l) => cli.log(l.value))
+    }))({app: 'fuzz'})
+    .then(() => {
+      expect(true, 'to equal', false)
+    })
+    .catch((err) => {
+      expect(err.body.id, 'to equal', 'two_factor')
+    })
+  })
+
+  it('2fa prompt error should propegate', function () {
+    let api = nock('https://api.heroku.com')
+
+    api.post('/foobar', {}).reply(403, {'id': 'two_factor'})
+
+    cli.prompt = function () {
+      return new Promise(function (resolve, reject) {
+        reject('error reading prompt')
+      })
+    }
+
+    return expect(command(co.wrap(function * (context, heroku) {
+      let foobar = yield heroku.post('/foobar', {body: {}})
+      cli.log(foobar.value)
+    }))({}), 'to be rejected with', 'error reading prompt')
+  })
+
+  it('non 2fa error should propagate', function () {
+    let api = nock('https://api.heroku.com')
+    api.post('/foobar', {}).reply(403, {'id': 'not_two_factor'})
+
+    return expect(command(co.wrap(function * (context, heroku) {
+      yield heroku.post('/foobar', {body: {}})
+    }))({}), 'to be rejected with', {statusCode: 403, body: { id: 'not_two_factor' }})
+  })
+
+  it('non json error should propagate', function () {
+    let api = nock('https://api.heroku.com')
+    api.post('/foobar', {}).reply(403, 'fizz')
+
+    return expect(command(co.wrap(function * (context, heroku) {
+      yield heroku.post('/foobar', {body: {}})
+    }))({}), 'to be rejected with', {body: 'fizz'})
+  })
+})

--- a/test/mutex.js
+++ b/test/mutex.js
@@ -1,0 +1,92 @@
+'use strict'
+/* globals describe it beforeEach */
+
+let cli = require('..')
+let Mutex = require('../lib/mutex')
+let expect = require('unexpected')
+
+describe('mutex', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+  })
+
+  it('should run promises in order', function () {
+    let mutex = new Mutex()
+    return Promise.all([
+      mutex.synchronize(function () {
+        return new Promise(function (resolve, reject) {
+          setTimeout(function () {
+            cli.log('foo')
+            resolve('foo')
+          }, 3)
+        })
+      }),
+      mutex.synchronize(function () {
+        return new Promise(function (resolve, reject) {
+          setTimeout(function () {
+            cli.log('bar')
+            resolve('bar')
+          }, 1)
+        })
+      })
+    ]).then((results) => {
+      expect(['foo', 'bar'], 'to equal', results)
+      expect(cli.stdout, 'to equal', 'foo\nbar\n')
+    })
+  })
+
+  it('should propegate errors', function () {
+    let mutex = new Mutex()
+    return Promise.all([
+      mutex.synchronize(function () {
+        return new Promise(function (resolve, reject) {
+          cli.log('foo')
+          resolve('foo')
+        })
+      }),
+      mutex.synchronize(function () {
+        return new Promise(function (resolve, reject) {
+          cli.log('bar')
+          reject(new Error('bar'))
+        })
+      }),
+      mutex.synchronize(function () {
+        return new Promise(function (resolve, reject) {
+          cli.log('biz')
+          resolve('biz')
+        })
+      })
+    ]).then((results) => {
+      expect(true, 'to equal', false)
+    }).catch((err) => {
+      expect(err.message, 'to equal', 'bar')
+      expect(cli.stdout, 'to equal', 'foo\nbar\nbiz\n')
+    })
+  })
+
+  it('should run promises after draining the queue', function (done) {
+    let mutex = new Mutex()
+    mutex.synchronize(function () {
+      return new Promise(function (resolve, reject) {
+        cli.log('foo')
+        resolve('foo')
+      })
+    }).then((results) => {
+      setImmediate(function () {
+        expect('foo', 'to equal', results)
+        expect(cli.stdout, 'to equal', 'foo\n')
+
+        return mutex.synchronize(function () {
+          return new Promise(function (resolve, reject) {
+            cli.log('bar')
+            resolve('bar')
+          })
+        }).then((results) => {
+          expect('bar', 'to equal', results)
+          expect(cli.stdout, 'to equal', 'foo\nbar\n')
+          done()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
@dickeyxxx could you review?  I ended up having to use a mutex around the 2fa prompts because when they are run in parallel they read simultaneously from the same stdin which would cause problems.  I also pushed down the prompt into the promise that is saved per app so that they are only prompted once per app.

The changes from https://github.com/heroku/heroku-cli-util/pull/90 are all in https://github.com/heroku/heroku-cli-util/commit/dee77bf13de05796336d7e14d8544d84d004b828