### PR TITLE
Do not try and preauth when no app passed

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -24,7 +24,7 @@ function twoFactorWrapper (options, preauths, context) {
     if (res.statusCode === 403 && body.id === 'two_factor' && !preauths.requests.includes(this)) {
       let self = this
       // default preauth to always happen unless explicitly disabled
-      if (options.preauth === false) {
+      if (options.preauth === false || !body.app) {
         twoFactorPrompt(options, preauths, context)
         .then(function (secondFactor) {
           self.options.headers = Object.assign({}, self.options.headers, {'Heroku-Two-Factor-Code': secondFactor})


### PR DESCRIPTION
Fixes the bug where `heroku login` two factor bombs out because there is no app passed back.