### PR TITLE
Set Heroku netrc entries to have newlines

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -39,6 +39,7 @@ function saveToken ({email, token}) {
     if (!netrc.machines[host]) netrc.machines[host] = {}
     netrc.machines[host].login = email
     netrc.machines[host].password = token
+    netrc.machines[host].internalWhitespace = "\n  "
   })
   netrc.saveSync()
 }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -39,8 +39,14 @@ function saveToken ({email, token}) {
     if (!netrc.machines[host]) netrc.machines[host] = {}
     netrc.machines[host].login = email
     netrc.machines[host].password = token
-    netrc.machines[host].internalWhitespace = '\n  '
   })
+  if (netrc.machines._tokens){
+    netrc.machines._tokens.forEach(token => {
+      if (hosts.includes(token.host)){
+        token.internalWhitespace = '\n  '
+      }
+    })
+  }
   netrc.saveSync()
 }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -40,9 +40,9 @@ function saveToken ({email, token}) {
     netrc.machines[host].login = email
     netrc.machines[host].password = token
   })
-  if (netrc.machines._tokens){
+  if (netrc.machines._tokens) {
     netrc.machines._tokens.forEach(token => {
-      if (hosts.includes(token.host)){
+      if (hosts.includes(token.host)) {
         token.internalWhitespace = '\n  '
       }
     })

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -39,7 +39,7 @@ function saveToken ({email, token}) {
     if (!netrc.machines[host]) netrc.machines[host] = {}
     netrc.machines[host].login = email
     netrc.machines[host].password = token
-    netrc.machines[host].internalWhitespace = "\n  "
+    netrc.machines[host].internalWhitespace = '\n  '
   })
   netrc.saveSync()
 }

--- a/test/auth.js
+++ b/test/auth.js
@@ -174,8 +174,10 @@ describe('auth', function () {
 
         expect(netrc.machines['api.heroku.com'].login, 'to equal', 'foo@bar.com')
         expect(netrc.machines['api.heroku.com'].password, 'to equal', 'token')
+        expect(netrc.machines['api.heroku.com'].internalWhitespace, 'to equal', "\n  ")
         expect(netrc.machines['git.heroku.com'].login, 'to equal', 'foo@bar.com')
         expect(netrc.machines['git.heroku.com'].password, 'to equal', 'token')
+        expect(netrc.machines['git.heroku.com'].internalWhitespace, 'to equal', "\n  ")
         api.done()
       })
   })

--- a/test/auth.js
+++ b/test/auth.js
@@ -174,10 +174,8 @@ describe('auth', function () {
 
         expect(netrc.machines['api.heroku.com'].login, 'to equal', 'foo@bar.com')
         expect(netrc.machines['api.heroku.com'].password, 'to equal', 'token')
-        expect(netrc.machines['api.heroku.com'].internalWhitespace, 'to equal', '\n  ')
         expect(netrc.machines['git.heroku.com'].login, 'to equal', 'foo@bar.com')
         expect(netrc.machines['git.heroku.com'].password, 'to equal', 'token')
-        expect(netrc.machines['git.heroku.com'].internalWhitespace, 'to equal', '\n  ')
         api.done()
       })
   })

--- a/test/auth.js
+++ b/test/auth.js
@@ -174,10 +174,10 @@ describe('auth', function () {
 
         expect(netrc.machines['api.heroku.com'].login, 'to equal', 'foo@bar.com')
         expect(netrc.machines['api.heroku.com'].password, 'to equal', 'token')
-        expect(netrc.machines['api.heroku.com'].internalWhitespace, 'to equal', "\n  ")
+        expect(netrc.machines['api.heroku.com'].internalWhitespace, 'to equal', '\n  ')
         expect(netrc.machines['git.heroku.com'].login, 'to equal', 'foo@bar.com')
         expect(netrc.machines['git.heroku.com'].password, 'to equal', 'token')
-        expect(netrc.machines['git.heroku.com'].internalWhitespace, 'to equal', "\n  ")
+        expect(netrc.machines['git.heroku.com'].internalWhitespace, 'to equal', '\n  ')
         api.done()
       })
   })


### PR DESCRIPTION
This change writes a `.netrc` file with Heroku entries that have newline delimiters instead of whitespace delims. For example, this should write:

```
machine api.foo.com
  login me@me.com
  password mypass
```

Instead of:

```
machine api.foo.com login me@me.com password mypass
```

This resolves a problem in which the [heroku-deploy library](https://github.com/heroku/heroku-maven-plugin/tree/master/heroku-deploy), which is used by a number of command-line Java tools, was unable to read the `.netrc` file. For examples, see [this Stackoverflow post](https://stackoverflow.com/questions/49823912/on-deploy-heroku-says-it-cant-find-api-key-even-though-ive-logged-in/49825623), and this [support ticket](https://support.heroku.com/tickets/572302).