### PR TITLE
chore: update heroku-client & bump ci node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,19 @@ jobs:
           curl -s https://codecov.io/bash | bash
       - store_test_results: &store_test_results
           path: ~/cli/reports
-  node-8:
+  node-12:
     <<: *test
     docker:
-      - image: node:8
+      - image: node:12
+  node-10:
+    <<: *test
+    docker:
+      - image: node:10
 
 workflows:
   version: 2
   test:
     jobs:
       - node-latest
-      - node-8
+      - node-12
+      - node-10

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chalk": "^2.4.1",
     "co": "^4.6.0",
     "got": "^8.3.1",
-    "heroku-client": "^3.0.7",
+    "heroku-client": "^3.1.0",
     "lodash": "^4.17.10",
     "netrc-parser": "^3.1.4",
     "opn": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1442,10 +1442,10 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-heroku-client@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/heroku-client/-/heroku-client-3.0.7.tgz#abf4fe47cf88814ba1e16a1409999b92a5f6f99d"
-  integrity sha512-wL8d3ufIWGzL8B2U7oPzN+SdcMt6LPqA/x4nb9pDG45IXpr8KO+N4dvX4Vycgn0WrJVDfQnQ1juctJsUwuoeww==
+heroku-client@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/heroku-client/-/heroku-client-3.1.0.tgz#7e3f6804d18a6ee9e3a774ff8bc9861b9b1a4725"
+  integrity sha512-UfGKwUm5duzzSVI8uUXlNAE1mus6uPxmZPji4vuG1ArV5DYL1rXsZShp0OoxraWdEwYoxCUrM6KGztC68x5EZQ==
   dependencies:
     is-retry-allowed "^1.0.0"
     tunnel-agent "^0.6.0"


### PR DESCRIPTION
Bumping this package will bring in the latest changes to `heroku-client` including [a patch](https://github.com/heroku/node-heroku-client/pull/101) that will fix header deprecation warning in node 12.

## Note
After merging turn on branch rules for the new node versions