### PR TITLE
Remove co

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ npm install heroku-cli-util --save
 
 ```js
 let cli = require('heroku-cli-util');
-yield cli.action('restarting dynos', co(function* () {
-  let app = yield heroku.get(`/apps/${context.app}`);
-  yield heroku.request({method: 'DELETE', path: `/apps/${app.name}/dynos`});
-}));
+await cli.action('restarting dynos', async function() {
+  let app = await heroku.get(`/apps/${context.app}`);
+  await heroku.request({method: 'DELETE', path: `/apps/${app.name}/dynos`});
+});
 
 // restarting dynos... done
 ```
@@ -29,7 +29,7 @@ yield cli.action('restarting dynos', co(function* () {
 
 ```js
 let cli   = require('heroku-cli-util');
-let email = yield cli.prompt('email', {});
+let email = await cli.prompt('email', {});
 console.log(`your email is: ${email}`);
 ```
 
@@ -50,7 +50,7 @@ Basic
 
 ```js
 let cli = require('heroku-cli-util');
-yield cli.confirmApp('appname', context.flags.confirm);
+await cli.confirmApp('appname', context.flags.confirm);
 
 // !     WARNING: Destructive Action
 // !     This command will affect the app appname
@@ -63,7 +63,7 @@ Custom message
 
 ```js
 let cli = require('heroku-cli-util');
-yield cli.confirmApp('appname', context.flags.confirm, 'foo');
+await cli.confirmApp('appname', context.flags.confirm, 'foo');
 
 // !     foo
 // !     To proceed, type appname or re-run this command with --confirm appname
@@ -185,7 +185,7 @@ Useful with `process.stdout.columns || 80`.
 ## Open Web Browser
 
 ```js
-yield cli.open('https://github.com');
+await cli.open('https://github.com');
 ```
 
 ## HTTP calls
@@ -194,7 +194,7 @@ yield cli.open('https://github.com');
 
 ```js
 let cli = require('heroku-cli-util');
-let rsp = yield cli.got('https://google.com');
+let rsp = await cli.got('https://google.com');
 ```
 
 ## Mocking
@@ -225,11 +225,9 @@ module.exports.commands = [
     command: 'info',
     needsAuth: true,
     needsApp: true,
-    run: cli.command(function (context, heroku) {
-      return co(function* () {
-        let app = yield heroku.get(`/apps/${context.app}`);
-        console.dir(app);
-      });
+    run: cli.command(async function (context, heroku) {
+      let app = await heroku.get(`/apps/${context.app}`);
+      console.dir(app);
     })
   }
 ];
@@ -248,11 +246,9 @@ module.exports.commands = [
     needsApp: true,
     run: cli.command(
       {preauth: true},
-      function (context, heroku) {
-        return co(function* () {
-          let app = yield heroku.get(`/apps/${context.app}`);
-          console.dir(app);
-        });
+      async function (context, heroku) {
+        let app = await heroku.get(`/apps/${context.app}`);
+        console.dir(app);
       }
     )
   }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const co = require('co')
 const cli = require('..')
 const vars = require('./vars')
 
@@ -50,33 +49,33 @@ function saveToken ({email, token}) {
   netrc.saveSync()
 }
 
-function * loginUserPass ({save, expires_in: expiresIn}) {
+async function loginUserPass ({save, expires_in: expiresIn}) {
   const {prompt} = require('./prompt')
 
   cli.log('Enter your Heroku credentials:')
-  let email = yield prompt('Email')
-  let password = yield prompt('Password', {hide: true})
+  let email = await prompt('Email')
+  let password = await prompt('Password', {hide: true})
 
   let auth
   try {
-    auth = yield createOAuthToken(email, password, expiresIn)
+    auth = await createOAuthToken(email, password, expiresIn)
   } catch (err) {
     if (!err.body || err.body.id !== 'two_factor') throw err
-    let secondFactor = yield prompt('Two-factor code', {mask: true})
-    auth = yield createOAuthToken(email, password, expiresIn, secondFactor)
+    let secondFactor = await prompt('Two-factor code', {mask: true})
+    auth = await createOAuthToken(email, password, expiresIn, secondFactor)
   }
   if (save) saveToken(auth)
   return auth
 }
 
-function * loginSSO ({save, browser}) {
+async function loginSSO ({save, browser}) {
   const {prompt} = require('./prompt')
 
   let url = process.env['SSO_URL']
   if (!url) {
     let org = process.env['HEROKU_ORGANIZATION']
     if (!org) {
-      org = yield prompt('Enter your organization name')
+      org = await prompt('Enter your organization name')
     }
     url = `https://sso.heroku.com/saml/${encodeURIComponent(org)}/init?cli=true`
   }
@@ -84,7 +83,7 @@ function * loginSSO ({save, browser}) {
   const open = require('./open')
 
   let openError
-  yield cli.action('Opening browser for login', open(url, browser)
+  await cli.action('Opening browser for login', open(url, browser)
     .catch(function (err) {
       openError = err
     })
@@ -94,9 +93,9 @@ function * loginSSO ({save, browser}) {
     cli.console.error(openError.message)
   }
 
-  let token = yield prompt('Enter your access token (typing will be hidden)', {hide: true})
+  let token = await prompt('Enter your access token (typing will be hidden)', {hide: true})
 
-  let account = yield cli.heroku.get('/account', {
+  let account = await cli.heroku.get('/account', {
     headers: {
       Authorization: `Bearer ${token}`
     }
@@ -106,7 +105,7 @@ function * loginSSO ({save, browser}) {
   return {token: token, email: account.email}
 }
 
-function * logout () {
+async function logout () {
   let token = cli.heroku.options.token
   if (token) {
     // for SSO logins we delete the session since those do not show up in
@@ -147,13 +146,13 @@ function * logout () {
         throw err
       })
 
-    let [, defaultAuthorization, authorizations] = yield [sessionsP, defaultAuthorizationP, authorizationsP]
+    let [, defaultAuthorization, authorizations] = await Promise.all([sessionsP, defaultAuthorizationP, authorizationsP])
 
     if (accessToken(defaultAuthorization) !== token) {
       for (let authorization of authorizations) {
         if (accessToken(authorization) === token) {
           // remove the matching access token from core services
-          yield cli.heroku.delete(`/oauth/authorizations/${authorization.id}`)
+          await cli.heroku.delete(`/oauth/authorizations/${authorization.id}`)
         }
       }
     }
@@ -174,14 +173,14 @@ function accessToken (authorization) {
   return authorization && authorization.access_token && authorization.access_token.token
 }
 
-function * login (options = {}) {
-  if (!options.skipLogout) yield logout()
+async function login (options = {}) {
+  if (!options.skipLogout) await logout()
 
   try {
     if (options['sso']) {
-      return yield loginSSO(options)
+      return await loginSSO(options)
     } else {
-      return yield loginUserPass(options)
+      return await loginUserPass(options)
     }
   } catch (e) {
     const {PromptMaskError} = require('./prompt')
@@ -202,7 +201,7 @@ function token () {
 }
 
 module.exports = {
-  login: co.wrap(login),
-  logout: co.wrap(logout),
+  login: login,
+  logout: logout,
   token
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "ansi-styles": "^3.2.1",
     "cardinal": "^2.0.1",
     "chalk": "^2.4.1",
-    "co": "^4.6.0",
     "got": "^8.3.1",
     "heroku-client": "^3.1.0",
     "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "unexpected": "^10.37.7"
   },
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 10.0.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Remove the dependency on `co`. This is a breaking change as it drops support for node versions < 8. We only support Node.js >= 10 on Heroku CLI as of the time of this writing, so I went ahead and dropped support for those versions via the `engines` field in package.json as well.