### PR TITLE
fix: handle nullish formats in tables

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -56,7 +56,8 @@ function table (data, options) {
         value = get(row, path)
       }
 
-      return this.format(value, row)
+      let formatted = this.format(value, row)
+      return formatted == null ? '' : formatted.toString()
     }
   }
 

--- a/test/table.js
+++ b/test/table.js
@@ -95,11 +95,12 @@ Bob Smith | USA`)
 
     {columns: [{key: 'Name'},
       {key: 'Name', label: 'Initials', format: initials},
-      {key: 'Country', format: highlight}]})
+      {key: 'Country', format: highlight},
+      {key: 'null column', format: () => null}]})
 
     expectOutput(out, `
-Name       Initials  Country
-─────────  ────────  ─────────────
+Name       Initials  Country        null column
+─────────  ────────  ─────────────  ───────────
 Jane Doe   J. D.     [[AUSTRALIA]]
 Bob Smith  B. S.     [[USA]]`)
   })


### PR DESCRIPTION
Currently if a table column has a format function that returns null the table output will fail. This pull request will ensure that if a format returns `null` or `undefined` that the resulting value used for the output in the table is an empty string (similar to the default handling of values)