### PR TITLE
chore: change package name back to original

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@heroku-cli/heroku-cli-util",
+  "name": "heroku-cli-util",
   "description": "Set of helpful CLI utilities",
   "version": "8.0.12",
   "author": "Heroku",


### PR DESCRIPTION
We need to change the package name back to the original so that we can publish to npm.