### PR TITLE
Update package name to new publisher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "heroku-cli-util",
+  "name": "@heroku/heroku-cli-util",
   "description": "Set of helpful CLI utilities",
   "version": "8.0.12",
   "author": "Heroku",


### PR DESCRIPTION
We're now able to publish new versions of this package, but only under the NPM `@heroku` org.

This PR is just to update the package name inside `package.json` manifest.