### PR TITLE
refactor: reimplement styled object and styled json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,8 +7,16 @@ module.exports = {
         'prefer-arrow-callback': 'off',
       },
     },
+    {
+      files: ['examples/**/*.ts', 'examples/**/*.js'],
+      rules: {
+        'unicorn/prefer-module': 'off',
+        'unicorn/prefer-top-level-await': 'off',
+      },
+    },
   ],
   rules: {
+    '@typescript-eslint/no-explicit-any': 'warn',
     camelcase: 'warn',
     'import/namespace': 'warn',
     indent: ['error', 2, {MemberExpression: 1}],

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Please provide a command name (login or logout)"
+  exit 1
+fi
+
+COMMAND=$1
+shift
+
+if [ ! -f "examples/$COMMAND.ts" ]; then
+  echo "Command '$COMMAND' not found in examples directory"
+  exit 1
+fi
+
+./node_modules/.bin/ts-node "examples/$COMMAND.ts" "$@" 

--- a/examples/styled-json-command.ts
+++ b/examples/styled-json-command.ts
@@ -1,0 +1,26 @@
+import {Command} from '@oclif/core'
+
+import {styledJSON} from '../src/ux/styled-json'
+
+export default class StyledJSONCommand extends Command {
+  static description = 'Example command demonstrating styledJSON usage'
+
+  async run() {
+    // Example data to display
+    const data = {
+      config: {
+        debug: true,
+        port: 3000,
+      },
+      features: ['feature1', 'feature2'],
+      name: 'Example App',
+      version: '1.0.0',
+    }
+
+    // Display the data using styledJS
+    styledJSON(data)
+  }
+}
+
+(StyledJSONCommand.run(process.argv.slice(2)) as any)
+  .catch(require('@oclif/core').Errors.handle)

--- a/examples/styled-object-command.ts
+++ b/examples/styled-object-command.ts
@@ -1,0 +1,26 @@
+import {Command} from '@oclif/core'
+
+import {styledObject} from '../src/ux/styled-object'
+
+export default class StyledObjectCommand extends Command {
+  static description = 'Example command demonstrating styledObject usage'
+
+  async run() {
+    // Example data to display
+    const data = {
+      config: {
+        debug: true,
+        port: 3000,
+      },
+      features: ['feature1', 'feature2'],
+      name: 'Example App',
+      version: '1.0.0',
+    }
+
+    // Display the data using styledObject
+    styledObject(data)
+  }
+}
+
+(StyledObjectCommand.run(process.argv.slice(2)) as any)
+  .catch(require('@oclif/core').Errors.handle)

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rm -rf dist",
+    "example": "sh examples/run.sh",
     "lint": "eslint . --ext .ts --config .eslintrc.js",
     "prepare": "npm run build",
     "test": "nyc mocha  --forbid-only \"test/**/*.test.ts\"",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import {exec} from './utils/pg/psql'
 // import {confirm} from './ux/confirm'
 // import {prompt} from './ux/prompt'
 // import {styledHeader} from './ux/styled-header'
-// import {styledJSON} from './ux/styled-json'
-// import {styledObject} from './ux/styled-object'
+import {styledJSON} from './ux/styled-json'
+import {styledObject} from './ux/styled-object'
 // import {table} from './ux/table'
 // import {wait} from './ux/wait'
 
@@ -42,8 +42,8 @@ export const hux = {
   // confirm,
   // prompt,
   // styledHeader,
-  // styledJSON,
-  // styledObject,
+  styledJSON,
+  styledObject,
   // table,
   // wait,
 }

--- a/src/ux/styled-json.ts
+++ b/src/ux/styled-json.ts
@@ -1,8 +1,6 @@
-// import {ux} from '@oclif/core'
+import {ux} from '@oclif/core'
 
-// export function styledJSON(obj: unknown): void {
-//   return ux.styledJSON(obj)
-// }
+export function styledJSON(obj: unknown): void {
+  ux.stdout(ux.colorizeJson(obj))
+}
 
-// Temporarily disabled UX functions
-export const disabled = true

--- a/src/ux/styled-object.ts
+++ b/src/ux/styled-object.ts
@@ -27,7 +27,7 @@ export function styledObject(obj: unknown, keys?: string[]) {
   const maxKeyLength = Math.max(...keyLengths) + 2
 
   const logKeyValue = (key: string, value: unknown): string =>
-    `${color.blue(key)}:` + ' '.repeat(maxKeyLength - key.length - 1) + prettyPrint(value)
+    `${color.cyan(key)}:` + ' '.repeat(maxKeyLength - key.length - 1) + prettyPrint(value)
 
   for (const [key, value] of Object.entries(obj)) {
     if (keys && !keys.includes(key)) continue

--- a/src/ux/styled-object.ts
+++ b/src/ux/styled-object.ts
@@ -1,8 +1,47 @@
-// import {ux} from '@oclif/core'
+import color from '@heroku-cli/color'
+import {ux} from '@oclif/core'
+import {inspect} from 'node:util'
 
-// export function styledObject(obj: unknown, keys?: string[]): void {
-//   return ux.styledObject(obj, keys)
-// }
+function prettyPrint(obj: unknown): string {
+  if (!obj) return inspect(obj)
+  if (typeof obj === 'string') return obj
+  if (typeof obj === 'number') return obj.toString()
+  if (typeof obj === 'boolean') return obj.toString()
+  if (typeof obj === 'object') {
+    return Object.entries(obj)
+      .map(([key, value]) => `${key}: ${inspect(value)}`)
+      .join(', ')
+  }
 
-// Temporarily disabled UX functions
-export const disabled = true
+  return inspect(obj)
+}
+
+export function styledObject(obj: unknown, keys?: string[]) {
+  if (!obj) return inspect(obj)
+  if (typeof obj === 'string') return obj
+  if (typeof obj === 'number') return obj.toString()
+  if (typeof obj === 'boolean') return obj.toString()
+
+  const output: string[] = []
+  const keyLengths = Object.keys(obj).map(key => key.toString().length)
+  const maxKeyLength = Math.max(...keyLengths) + 2
+
+  const logKeyValue = (key: string, value: unknown): string =>
+    `${color.blue(key)}:` + ' '.repeat(maxKeyLength - key.length - 1) + prettyPrint(value)
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (keys && !keys.includes(key)) continue
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        output.push(logKeyValue(key, value[0]))
+        for (const e of value.slice(1)) {
+          output.push(' '.repeat(maxKeyLength) + prettyPrint(e))
+        }
+      }
+    } else if (value !== null && value !== undefined) {
+      output.push(logKeyValue(key, value))
+    }
+  }
+
+  ux.stdout(output.join('\n'))
+}

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -1,15 +1,15 @@
 // import {initCliTest} from '../src/test-helpers/init'
 // import {restoreStdoutStderr, setupStdoutStderr} from '../src/test-helpers/stub-output'
+import {stdout} from 'stdout-stderr'
 
 exports.mochaHooks = {
   afterEach(done: () => void) {
-    // initCliTest()
-    // restoreStdoutStderr()
+    stdout.stop()
     done()
   },
 
   beforeEach(done: () => void) {
-    // setupStdoutStderr()
+    stdout.start()
     done()
   },
 }

--- a/test/unit/ux/styled-json.test.ts
+++ b/test/unit/ux/styled-json.test.ts
@@ -1,22 +1,25 @@
-// import heredoc from 'tsheredoc'
+import {expect} from 'chai'
+import {stdout} from 'stdout-stderr'
+import heredoc from 'tsheredoc'
 
-// import expectOutput from '../../../src/test-helpers/expect-output'
-// import {stdout} from '../../../src/test-helpers/stub-output'
-// import {styledJSON} from '../../../src/ux/styled-json'
+import {styledJSON} from '../../../src/ux/styled-json'
 
-// import stripAnsi = require('strip-ansi');
+import stripAnsi = require('strip-ansi')
 
-describe.skip('styledObject', function () {
+describe('styledJSON', function () {
   it('should print the correct styled object output', function () {
-    // const obj = {baz: 42, foo: 'bar'}
-    // styledJSON(obj)
-    // const expected = heredoc(`
-    //   {
-    //     "baz": 42,
-    //     "foo": "bar"
-    //   }
-    // `)
-    // const actual = stripAnsi(stdout())
-    // expectOutput(expected, actual)
+    const obj = {baz: 42, foo: 'bar', test: {one: 'two'}}
+    styledJSON(obj)
+    const expected = heredoc(`
+      {
+        "baz": 42,
+        "foo": "bar",
+        "test": {
+          "one": "two"
+        }
+      }
+    `)
+    const actual = stripAnsi(stdout.output)
+    expect(actual).to.equal(expected)
   })
 })

--- a/test/unit/ux/styled-object.test.ts
+++ b/test/unit/ux/styled-object.test.ts
@@ -1,21 +1,21 @@
-// import heredoc from 'tsheredoc'
+import {expect} from 'chai'
+import {stdout} from 'stdout-stderr'
+import heredoc from 'tsheredoc'
 
-// import expectOutput from '../../../src/test-helpers/expect-output'
-// import {stdout} from '../../../src/test-helpers/stub-output'
-// import {styledObject} from '../../../src/ux/styled-object'
+import {styledObject} from '../../../src/ux/styled-object'
 
-// import stripAnsi = require('strip-ansi');
+import stripAnsi = require('strip-ansi')
 
-describe.skip('styledObject', function () {
+describe('styledObject', function () {
   it('should print the correct styled object output', function () {
-    // const obj = {baz: 42, foo: 'bar'}
-    // styledObject(obj)
-    // const expected = heredoc(`
-    //   baz: 42
-    //   foo: bar
-    // `)
-    // const actual = stripAnsi(stdout())
-    // expectOutput(expected, actual)
+    const obj = {baz: 42, foo: 'bar'}
+    styledObject(obj)
+    const expected = heredoc(`
+      baz: 42
+      foo: bar
+    `)
+    const actual = stripAnsi(stdout.output)
+    expect(actual).to.equal(expected)
   })
 })
 


### PR DESCRIPTION
[W-18294171](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002CuR1XYAV/view)

### Description

This reimplements `styledObject` and `styledJSON` without using deprecated oclif `ux` functions.

### Testing

I've added examples to test the ux functions. You can run them and review how they look:
1. npm run example styled-json-command
2. npm run example styled-object-command