### PR TITLE
refactor!: reimplement wait and prompt, add back pg utilities

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,27 +1,19 @@
 module.exports = {
-  extends: ['oclif', 'oclif-typescript'],
+  env: {
+    node: true,
+  },
+  extends: ['./node_modules/@heroku-cli/test-utils/dist/eslint-config.js'],
   overrides: [
     {
-      files: ['test/**/*.ts', 'test/**/*.js'],
+      files: ['src/**/*.ts'],
       rules: {
-        'prefer-arrow-callback': 'off',
-      },
-    },
-    {
-      files: ['examples/**/*.ts', 'examples/**/*.js'],
-      rules: {
-        'unicorn/prefer-module': 'off',
-        'unicorn/prefer-top-level-await': 'off',
+        '@typescript-eslint/no-explicit-any': 'warn',
       },
     },
   ],
-  rules: {
-    '@typescript-eslint/no-explicit-any': 'warn',
-    camelcase: 'warn',
-    'import/namespace': 'warn',
-    indent: ['error', 2, {MemberExpression: 1}],
-    'no-console': 'off',
-    'unicorn/no-empty-file': 'warn',
-    'unicorn/prefer-string-replace-all': 'warn',
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
   },
 }

--- a/examples/confirm-command.ts
+++ b/examples/confirm-command.ts
@@ -16,7 +16,9 @@ export default class ConfirmCommand extends Command {
   }
 }
 
-ConfirmCommand.run(process.argv.slice(2)).catch(error => {
+try {
+  await ConfirmCommand.run(process.argv.slice(2))
+} catch (error) {
   console.error('Error:', error)
   throw error
-})
+}

--- a/examples/prompt-command.ts
+++ b/examples/prompt-command.ts
@@ -1,0 +1,22 @@
+import {Command, ux} from '@oclif/core'
+
+import {prompt} from '../src/ux/prompt.js'
+
+export default class PromptCommand extends Command {
+  static description = 'Example command demonstrating prompt usage'
+
+  async run() {
+    const name = await prompt('What is your name?', {required: true})
+    const favoriteColor = await prompt('What is your favorite color?', {
+      default: 'blue',
+      required: false,
+    })
+
+    ux.stdout(`Hello ${name}! Your favorite color is ${favoriteColor}.`)
+  }
+}
+
+PromptCommand.run(process.argv.slice(2)).catch(error => {
+  console.error('Error:', error)
+  throw error
+})

--- a/examples/prompt-command.ts
+++ b/examples/prompt-command.ts
@@ -16,7 +16,10 @@ export default class PromptCommand extends Command {
   }
 }
 
-PromptCommand.run(process.argv.slice(2)).catch(error => {
+// Execute the command
+try {
+  await PromptCommand.run(process.argv.slice(2))
+} catch (error) {
   console.error('Error:', error)
   throw error
-})
+}

--- a/examples/styled-header-command.ts
+++ b/examples/styled-header-command.ts
@@ -11,7 +11,10 @@ export default class StyledJSONCommand extends Command {
   }
 }
 
-StyledJSONCommand.run(process.argv.slice(2)).catch(error => {
+// Execute the command
+try {
+  await StyledJSONCommand.run(process.argv.slice(2))
+} catch (error) {
   console.error('Error:', error)
   throw error
-})
+}

--- a/examples/styled-json-command.ts
+++ b/examples/styled-json-command.ts
@@ -22,5 +22,10 @@ export default class StyledJSONCommand extends Command {
   }
 }
 
-(StyledJSONCommand.run(process.argv.slice(2)) as any)
-  .catch(require('@oclif/core').Errors.handle)
+// Execute the command
+try {
+  await StyledJSONCommand.run(process.argv.slice(2))
+} catch (error) {
+  console.error('Error:', error)
+  throw error
+}

--- a/examples/styled-object-command.ts
+++ b/examples/styled-object-command.ts
@@ -22,5 +22,10 @@ export default class StyledObjectCommand extends Command {
   }
 }
 
-(StyledObjectCommand.run(process.argv.slice(2)) as any)
-  .catch(require('@oclif/core').Errors.handle)
+// Execute the command
+try {
+  await StyledObjectCommand.run(process.argv.slice(2))
+} catch (error) {
+  console.error('Error:', error)
+  throw error
+}

--- a/examples/table-command.ts
+++ b/examples/table-command.ts
@@ -56,7 +56,9 @@ export default class TableCommand extends Command {
 }
 
 // Execute the command
-TableCommand.run(process.argv.slice(2)).catch(error => {
+try {
+  await TableCommand.run(process.argv.slice(2))
+} catch (error) {
   console.error('Error:', error)
   throw error
-})
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@heroku-cli/schema": "^2.0.0",
+        "@heroku-cli/test-utils": "0.1.1",
         "@types/chai": "^4.3.13",
         "@types/chai-as-promised": "^8.0.2",
         "@types/debug": "^4.1.12",
@@ -877,6 +878,132 @@
         "sinon": "^18.0.1"
       }
     },
+    "node_modules/@heroku-cli/test-utils/node_modules/@heroku-cli/command": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-11.5.0.tgz",
+      "integrity": "sha512-tUGmJbnRiBinJk9/OgP1w80YyQFnqgVQCySJoR2juBp9JjcwYPK8pIyO/P5xiL1+Aj69w4KbguDZVGWP079UKg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@heroku-cli/color": "^2.0.1",
+        "@heroku/http-call": "^5.4.0",
+        "@oclif/core": "^2.16.0",
+        "cli-ux": "^6.0.9",
+        "debug": "^4.4.0",
+        "fs-extra": "^9.1.0",
+        "heroku-client": "^3.1.0",
+        "netrc-parser": "^3.1.6",
+        "open": "^8.4.2",
+        "uuid": "^8.3.0",
+        "yargs-parser": "^18.1.3",
+        "yargs-unparser": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@heroku-cli/test-utils/node_modules/@oclif/core": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.16.0.tgz",
+      "integrity": "sha512-dL6atBH0zCZl1A1IXCKJgLPrM/wR7K+Wi401E/IvqsK8m2iCHW+0TEOGrans/cuN3oTW+uxIyJFHJ8Im0k4qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cli-progress": "^3.11.0",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.12.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.8",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
+        "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@heroku-cli/test-utils/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@heroku-cli/test-utils/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@heroku-cli/test-utils/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@heroku-cli/test-utils/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/test-utils/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@heroku/http-call": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@heroku/http-call/-/http-call-5.4.0.tgz",
@@ -1529,6 +1656,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@oclif/linewrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
+      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@oclif/screen": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
+      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
+      "deprecated": "Deprecated in favor of @oclif/core",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oclif/table": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/@oclif/table/-/table-0.4.8.tgz",
@@ -1747,6 +1892,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/chai": "*"
+      }
+    },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.6.tgz",
+      "integrity": "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -2473,6 +2628,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ansis": {
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
@@ -2680,6 +2842,16 @@
         "node": "*"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -2694,6 +2866,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/auto-bind": {
@@ -3012,6 +3194,20 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      },
+      "bin": {
+        "cdl": "bin/cdl.js"
+      }
+    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -3223,6 +3419,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
@@ -3339,6 +3548,146 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-ux": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-6.0.9.tgz",
+      "integrity": "sha512-0Ku29QLf+P6SeBNWM7zyoJ49eKKOjxZBZ4OH2aFeRtC0sNXU3ftdJxQPKJ1SJ+axX34I1NsfTFahpXdnxklZgA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oclif/core": "^1.1.1",
+        "@oclif/linewrap": "^1.0.0",
+        "@oclif/screen": "^1.0.4 ",
+        "ansi-escapes": "^4.3.0",
+        "ansi-styles": "^4.2.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.0",
+        "clean-stack": "^3.0.0",
+        "cli-progress": "^3.10.0",
+        "extract-stack": "^2.0.0",
+        "fs-extra": "^8.1",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.21",
+        "natural-orderby": "^2.0.1",
+        "object-treeify": "^1.1.4",
+        "password-prompt": "^1.1.2",
+        "semver": "^7.3.2",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "supports-color": "^8.1.0",
+        "supports-hyperlinks": "^2.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cli-ux/node_modules/@oclif/core": {
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.26.2.tgz",
+      "integrity": "sha512-6jYuZgXvHfOIc9GIaS4T3CIKGTjPmfAxuMcbCbMRKJJl4aq/4xeRlEz0E8/hz8HxvxZBGvN2GwAUHlrGWQVrVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oclif/linewrap": "^1.0.0",
+        "@oclif/screen": "^3.0.4",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.10.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.6",
+        "fs-extra": "^9.1.0",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "semver": "^7.3.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "tslib": "^2.4.1",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/cli-ux/node_modules/@oclif/core/node_modules/@oclif/screen": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.8.tgz",
+      "integrity": "sha512-yx6KAqlt3TAHBduS2fMQtJDL2ufIHnDRArrJEOoTTuizxqmjLT+psGYOHpmMl3gvQpFJ11Hs76guUUktzAF9Bg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cli-ux/node_modules/@oclif/core/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-ux/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/cli-ux/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/cli-ux/node_modules/fs-extra/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/cli-width": {
@@ -4853,6 +5202,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/extract-stack": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
+      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5109,6 +5468,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -5553,6 +5928,30 @@
         "he": "bin/he"
       }
     },
+    "node_modules/heroku-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/heroku-client/-/heroku-client-3.1.0.tgz",
+      "integrity": "sha512-UfGKwUm5duzzSVI8uUXlNAE1mus6uPxmZPji4vuG1ArV5DYL1rXsZShp0OoxraWdEwYoxCUrM6KGztC68x5EZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^1.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/heroku-client/node_modules/is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -5566,6 +5965,16 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hyperlinker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
+      "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -6766,6 +7175,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/just-extend": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
@@ -7167,6 +7589,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/natural-orderby": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
+      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/netrc-parser": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/netrc-parser/-/netrc-parser-3.1.6.tgz",
@@ -7565,6 +7997,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/object-treeify": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
+      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/object.assign": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
@@ -7899,6 +8341,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/password-prompt": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
+      "integrity": "sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==",
+      "dev": true,
+      "license": "0BSD",
+      "dependencies": {
+        "ansi-escapes": "^4.3.2",
+        "cross-spawn": "^7.0.3"
       }
     },
     "node_modules/patch-console": {
@@ -8326,6 +8779,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redeyed": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "~4.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8922,6 +9385,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9281,6 +9762,33 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -9706,6 +10214,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/color": "^2.0.4",
-        "@heroku-cli/command": "^11.5.0",
+        "@heroku-cli/command": "^12.0.0",
         "@heroku/http-call": "^5.4.0",
         "@oclif/core": "^4.3.0",
         "@oclif/table": "0.4.8",
@@ -385,6 +385,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -573,96 +574,271 @@
       "license": "0BSD"
     },
     "node_modules/@heroku-cli/command": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-11.5.0.tgz",
-      "integrity": "sha512-tUGmJbnRiBinJk9/OgP1w80YyQFnqgVQCySJoR2juBp9JjcwYPK8pIyO/P5xiL1+Aj69w4KbguDZVGWP079UKg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-12.0.0.tgz",
+      "integrity": "sha512-Bik5UgedlKmTRDE8tqUQyTMH1D/ju0/wcQYXdWYVi8GeSkhoR167zje/r+qh7zADWKanneKZJiSNNy50tT14WQ==",
       "license": "ISC",
       "dependencies": {
-        "@heroku-cli/color": "^2.0.1",
+        "@heroku-cli/color": "^2.0.4",
         "@heroku/http-call": "^5.4.0",
-        "@oclif/core": "^2.16.0",
-        "cli-ux": "^6.0.9",
+        "@oclif/core": "^4.3.0",
         "debug": "^4.4.0",
-        "fs-extra": "^9.1.0",
-        "heroku-client": "^3.1.0",
+        "inquirer": "^8.2.6",
+        "inquirer-press-to-continue": "^1.2.0",
         "netrc-parser": "^3.1.6",
-        "open": "^8.4.2",
-        "uuid": "^8.3.0",
-        "yargs-parser": "^18.1.3",
+        "open": "^10.1.2",
+        "yargs-parser": "^20.2.9",
         "yargs-unparser": "^2.0.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
-    "node_modules/@heroku-cli/command/node_modules/@oclif/core": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.16.0.tgz",
-      "integrity": "sha512-dL6atBH0zCZl1A1IXCKJgLPrM/wR7K+Wi401E/IvqsK8m2iCHW+0TEOGrans/cuN3oTW+uxIyJFHJ8Im0k4qBw==",
+    "node_modules/@heroku-cli/command/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "license": "MIT",
       "dependencies": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.12.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.8",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "ts-node": "^10.9.1",
-        "tslib": "^2.5.0",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
+        "restore-cursor": "^3.1.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=8"
       }
     },
-    "node_modules/@heroku-cli/command/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@heroku-cli/command/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@heroku-cli/command/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+    "node_modules/@heroku-cli/command/node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/inquirer": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "license": "MIT",
       "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/inquirer-press-to-continue": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer-press-to-continue/-/inquirer-press-to-continue-1.2.0.tgz",
+      "integrity": "sha512-HdKOgEAydYhI3OKLy5S4LMi7a/AHJjPzF06mHqbdVxlTmHOaytQVBaVbQcSytukD70K9FYLhYicNOPuNjFiWVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "^2.2.0",
+        "ora": "^6.1.2"
+      },
+      "peerDependencies": {
+        "inquirer": ">=8.0.0 <10.0.0"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/inquirer-press-to-continue/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/inquirer-press-to-continue/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/inquirer-press-to-continue/node_modules/ora": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
+      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/inquirer-press-to-continue/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/inquirer-press-to-continue/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "license": "ISC"
+    },
+    "node_modules/@heroku-cli/command/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@heroku-cli/schema": {
@@ -1208,6 +1384,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1227,12 +1404,14 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1348,22 +1527,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@oclif/linewrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
-      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
-      "license": "ISC"
-    },
-    "node_modules/@oclif/screen": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
-      "deprecated": "Deprecated in favor of @oclif/core",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@oclif/table": {
@@ -1534,24 +1697,28 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1580,15 +1747,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/chai": "*"
-      }
-    },
-    "node_modules/@types/cli-progress": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.6.tgz",
-      "integrity": "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -1644,6 +1802,7 @@
       "version": "22.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
       "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2192,6 +2351,7 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2214,6 +2374,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -2312,12 +2473,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/ansicolors": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
-      "license": "MIT"
-    },
     "node_modules/ansis": {
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
@@ -2365,12 +2520,14 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -2380,7 +2537,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -2524,15 +2680,6 @@
         "node": "*"
       }
     },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -2547,15 +2694,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/auto-bind": {
@@ -2574,7 +2712,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -2590,6 +2727,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
@@ -2612,6 +2769,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2676,6 +2844,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -2699,6 +2891,21 @@
         "semver": "^7.0.0"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -2719,7 +2926,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -2738,7 +2944,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2752,7 +2957,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2807,19 +3011,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/cardinal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
-      "license": "MIT",
-      "dependencies": {
-        "ansicolors": "~0.3.2",
-        "redeyed": "~2.1.0"
-      },
-      "bin": {
-        "cdl": "bin/cdl.js"
-      }
     },
     "node_modules/chai": {
       "version": "4.5.0",
@@ -3032,18 +3223,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-progress": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
-      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
@@ -3162,139 +3341,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/cli-ux": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-6.0.9.tgz",
-      "integrity": "sha512-0Ku29QLf+P6SeBNWM7zyoJ49eKKOjxZBZ4OH2aFeRtC0sNXU3ftdJxQPKJ1SJ+axX34I1NsfTFahpXdnxklZgA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/core": "^1.1.1",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4 ",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.10.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/@oclif/core": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.26.2.tgz",
-      "integrity": "sha512-6jYuZgXvHfOIc9GIaS4T3CIKGTjPmfAxuMcbCbMRKJJl4aq/4xeRlEz0E8/hz8HxvxZBGvN2GwAUHlrGWQVrVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.4",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/@oclif/core/node_modules/@oclif/screen": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.8.tgz",
-      "integrity": "sha512-yx6KAqlt3TAHBduS2fMQtJDL2ufIHnDRArrJEOoTTuizxqmjLT+psGYOHpmMl3gvQpFJ11Hs76guUUktzAF9Bg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/@oclif/core/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cli-ux/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/fs-extra/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/cli-ux/node_modules/fs-extra/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -3314,6 +3360,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/code-excerpt": {
@@ -3408,12 +3463,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3526,12 +3583,72 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.1",
@@ -3559,11 +3676,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -3578,19 +3706,21 @@
       }
     },
     "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -3608,6 +3738,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -3642,7 +3773,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3773,7 +3903,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3783,17 +3912,35 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4542,6 +4689,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -4705,15 +4853,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/extract-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4758,6 +4897,30 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4885,7 +5048,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -4948,21 +5110,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4989,7 +5136,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5020,7 +5166,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5072,7 +5217,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5106,7 +5250,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5263,7 +5406,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5276,6 +5418,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -5289,7 +5432,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5311,7 +5453,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -5340,7 +5481,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5353,7 +5493,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5396,7 +5535,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5415,28 +5553,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/heroku-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/heroku-client/-/heroku-client-3.1.0.tgz",
-      "integrity": "sha512-UfGKwUm5duzzSVI8uUXlNAE1mus6uPxmZPji4vuG1ArV5DYL1rXsZShp0OoxraWdEwYoxCUrM6KGztC68x5EZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-retry-allowed": "^1.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/heroku-client/node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -5451,15 +5567,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/hyperlinker": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
-      "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5471,6 +5578,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5543,7 +5670,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ink": {
@@ -5800,7 +5926,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5811,11 +5936,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -5860,7 +6000,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
@@ -5889,7 +6028,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -5932,7 +6070,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5979,7 +6116,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6087,11 +6223,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6113,7 +6290,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -6149,7 +6325,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6180,7 +6355,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6193,7 +6367,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -6221,7 +6394,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -6238,7 +6410,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6279,7 +6450,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6292,7 +6462,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6321,7 +6490,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -6360,7 +6528,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6528,6 +6695,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -6596,18 +6764,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/just-extend": {
@@ -6714,7 +6870,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -6789,13 +6944,13 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7011,15 +7166,6 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/natural-orderby": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
-      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/netrc-parser": {
       "version": "3.1.6",
@@ -7386,8 +7532,23 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -7399,26 +7560,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-treeify": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
-      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -7514,17 +7664,33 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
       "license": "MIT",
       "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7546,6 +7712,54 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/os-tmpdir": {
@@ -7687,16 +7901,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/password-prompt": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
-      "integrity": "sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==",
-      "license": "0BSD",
-      "dependencies": {
-        "ansi-escapes": "^4.3.2",
-        "cross-spawn": "^7.0.3"
-      }
-    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -7730,6 +7934,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7873,7 +8078,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8097,6 +8301,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -8108,15 +8326,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/redeyed": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "esprima": "~4.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8156,7 +8365,6 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -8344,6 +8552,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-async": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
@@ -8446,7 +8666,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8508,7 +8727,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -8526,7 +8744,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -8557,6 +8774,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8569,6 +8787,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8578,7 +8797,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8598,7 +8816,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8615,7 +8832,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8634,7 +8850,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8705,23 +8920,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/source-map": {
@@ -8806,6 +9004,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ssh2": {
@@ -8853,6 +9052,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
+      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stdin-discarder/node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/stdin-discarder/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/stdout-stderr": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/stdout-stderr/-/stdout-stderr-0.1.13.tgz",
@@ -8865,6 +9114,28 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -9012,31 +9283,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-hyperlinks/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -9092,6 +9338,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -9180,6 +9432,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -9418,6 +9671,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9450,16 +9704,8 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.7.2",
@@ -9535,10 +9781,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -9548,6 +9801,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
@@ -9561,10 +9815,20 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9580,7 +9844,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
@@ -9628,7 +9891,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
@@ -9654,7 +9916,6 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -9805,7 +10066,6 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -9830,6 +10090,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "nock": "^13.2.9",
         "nyc": "^17.1.0",
         "sinon": "^18.0.1",
-        "stdout-stderr": "^0.1.13",
         "strip-ansi": "^6",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "nock": "^13.2.9",
     "nyc": "^17.1.0",
     "sinon": "^18.0.1",
-    "stdout-stderr": "^0.1.13",
     "strip-ansi": "^6",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "example": "sh examples/run.sh",
     "lint": "eslint . --ext .ts --config .eslintrc.cjs",
     "prepare": "npm run build",
-    "test": "nyc mocha --forbid-only \"test/**/*.test.+(ts|tsx)\"",
+    "test": "nyc mocha --forbid-only \"${npm_config_file:-test/**/*.test.+(ts|tsx)}\"",
     "test:local": "nyc mocha \"test/**/*.test.ts\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@heroku-cli/color": "^2.0.4",
-    "@heroku-cli/command": "^11.5.0",
+    "@heroku-cli/command": "^12.0.0",
     "@heroku/http-call": "^5.4.0",
     "@oclif/core": "^4.3.0",
     "@oclif/table": "0.4.8",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "example": "sh examples/run.sh",
     "lint": "eslint . --ext .ts --config .eslintrc.cjs",
     "prepare": "npm run build",
-    "test": "nyc mocha --forbid-only \"${npm_config_file:-test/**/*.test.+(ts|tsx)}\"",
-    "test:local": "nyc mocha \"test/**/*.test.ts\""
+    "test": "nyc mocha --forbid-only \"test/**/*.test.ts\"",
+    "test:local": "nyc mocha \"${npm_config_file:-test/**/*.test.+(ts|tsx)}\""
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,10 @@ import {AddOnAttachmentWithConfigVarsAndPlan, AddOnWithRelatedData, Link} from '
 import {ConnectionDetails, ConnectionDetailsWithAttachment, TunnelConfig} from './types/pg/tunnel.js'
 import {getDatabase} from './utils/pg/databases.js'
 import getHost from './utils/pg/host.js'
-// import {exec} from './utils/pg/psql.js'
+import {exec} from './utils/pg/psql.js'
 import {confirm} from './ux/confirm.js'
+import {prompt} from './ux/prompt.js'
 import {styledHeader} from './ux/styled-header.js'
-// import {prompt} from './ux/prompt'
 import {styledJSON} from './ux/styled-json.js'
 import {styledObject} from './ux/styled-object.js'
 import {table} from './ux/table.js'
@@ -32,15 +32,15 @@ export const utils = {
     databases: getDatabase,
     host: getHost,
     psql: {
-      // exec,
+      exec,
     },
   },
 }
 
 export const hux = {
   confirm,
+  prompt,
   styledHeader,
-  // prompt,
   styledJSON,
   styledObject,
   table,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import {AmbiguousError} from './types/errors/ambiguous.js'
 import {NotFound} from './types/errors/not-found.js'
 import {AddOnAttachmentWithConfigVarsAndPlan, AddOnWithRelatedData, Link} from './types/pg/data-api.js'
 import {ConnectionDetails, ConnectionDetailsWithAttachment, TunnelConfig} from './types/pg/tunnel.js'
-// import {getDatabase} from './utils/pg/databases.js'
+import {getDatabase} from './utils/pg/databases.js'
 import getHost from './utils/pg/host.js'
 // import {exec} from './utils/pg/psql.js'
 import {confirm} from './ux/confirm.js'
@@ -11,7 +11,7 @@ import {styledHeader} from './ux/styled-header.js'
 import {styledJSON} from './ux/styled-json.js'
 import {styledObject} from './ux/styled-object.js'
 import {table} from './ux/table.js'
-
+import {wait} from './ux/wait.js'
 export const types = {
   errors: {
     AmbiguousError,
@@ -29,7 +29,7 @@ export const types = {
 
 export const utils = {
   pg: {
-    // databases: getDatabase,
+    databases: getDatabase,
     host: getHost,
     psql: {
       // exec,
@@ -44,5 +44,5 @@ export const hux = {
   styledJSON,
   styledObject,
   table,
-  // wait,
+  wait,
 }

--- a/src/utils/pg/bastion.ts
+++ b/src/utils/pg/bastion.ts
@@ -1,143 +1,144 @@
-// import type {APIClient} from '@heroku-cli/command'
+import type {APIClient} from '@heroku-cli/command'
 
-// // import {ux} from '@oclif/core'
-// import debug from 'debug'
-// import * as EventEmitter from 'node:events'
-// import {promisify} from 'node:util'
-// import * as createTunnel from 'tunnel-ssh'
+import {ux} from '@oclif/core'
+import debug from 'debug'
+import * as EventEmitter from 'node:events'
+import {promisify} from 'node:util'
+import * as createTunnel from 'tunnel-ssh'
 
-// import {AddOnAttachmentWithConfigVarsAndPlan} from '../../types/pg/data-api'
-// import {ConnectionDetails} from '../../types/pg/tunnel'
-// import {TunnelConfig} from '../../types/pg/tunnel'
-// import host from './host'
-// const pgDebug = debug('pg')
+import {AddOnAttachmentWithConfigVarsAndPlan} from '../../types/pg/data-api.js'
+import {ConnectionDetails} from '../../types/pg/tunnel.js'
+import {TunnelConfig} from '../../types/pg/tunnel.js'
+import host from './host.js'
+const pgDebug = debug('pg')
 
-// export const bastionKeyPlan = (a: AddOnAttachmentWithConfigVarsAndPlan) => Boolean(/private/.test(a.addon.plan.name))
+export const bastionKeyPlan = (a: AddOnAttachmentWithConfigVarsAndPlan) => Boolean(/private/.test(a.addon.plan.name))
 
-// export const env = (db: ConnectionDetails) => {
-//   const baseEnv = {
-//     PGAPPNAME: 'psql non-interactive',
-//     PGSSLMODE: (!db.host || db.host === 'localhost') ? 'prefer' : 'require',
-//     ...process.env,
-//   }
+export const env = (db: ConnectionDetails) => {
+  const baseEnv = {
+    PGAPPNAME: 'psql non-interactive',
+    PGSSLMODE: (!db.host || db.host === 'localhost') ? 'prefer' : 'require',
+    ...process.env,
+  }
 
-//   const mapping: Record<string, keyof Omit<typeof db, '_tunnel' | 'bastionHost' | 'bastionKey' | 'pathname' | 'url'>> = {
-//     PGDATABASE: 'database',
-//     PGHOST: 'host',
-//     PGPASSWORD: 'password',
-//     PGPORT: 'port',
-//     PGUSER: 'user',
-//   }
-//   for (const envVar of Object.keys(mapping)) {
-//     const val = db[mapping[envVar]]
-//     if (val) {
-//       baseEnv[envVar as keyof typeof baseEnv] = val as string
-//     }
-//   }
+  const mapping: Record<string, keyof Omit<typeof db, '_tunnel' | 'bastionHost' | 'bastionKey' | 'pathname' | 'url'>> = {
+    PGDATABASE: 'database',
+    PGHOST: 'host',
+    PGPASSWORD: 'password',
+    PGPORT: 'port',
+    PGUSER: 'user',
+  }
+  for (const envVar of Object.keys(mapping)) {
+    const val = db[mapping[envVar]]
+    if (val) {
+      baseEnv[envVar as keyof typeof baseEnv] = val as string
+    }
+  }
 
-//   return baseEnv
-// }
+  return baseEnv
+}
 
-// export async function fetchConfig(heroku:APIClient, db: {id: string}) {
-//   return heroku.get<{host: string, private_key:string}>(
-//     `/client/v11/databases/${encodeURIComponent(db.id)}/bastion`,
-//     {
-//       hostname: host(),
-//     },
-//   )
-// }
+export async function fetchConfig(heroku:APIClient, db: {id: string}) {
+  return heroku.get<{host: string, private_key:string}>(
+    `/client/v11/databases/${encodeURIComponent(db.id)}/bastion`,
+    {
+      hostname: host(),
+    },
+  )
+}
 
-// export const getBastion = function (config:Record<string, string>, baseName: string) {
-//   // If there are bastions, extract a host and a key
-//   // otherwise, return an empty Object
+export const getBastion = function (config:Record<string, string>, baseName: string) {
+  // If there are bastions, extract a host and a key
+  // otherwise, return an empty Object
 
-//   // If there are bastions:
-//   // * there should be one *_BASTION_KEY
-//   // * pick one host from the comma-separated list in *_BASTIONS
-//   // We assert that _BASTIONS and _BASTION_KEY always exist together
-//   // If either is falsy, pretend neither exist
+  // If there are bastions:
+  // * there should be one *_BASTION_KEY
+  // * pick one host from the comma-separated list in *_BASTIONS
+  // We assert that _BASTIONS and _BASTION_KEY always exist together
+  // If either is falsy, pretend neither exist
 
-//   const bastionKey = config[`${baseName}_BASTION_KEY`]
-//   const bastions = (config[`${baseName}_BASTIONS`] || '').split(',')
-//   const bastionHost = bastions[Math.floor(Math.random() * bastions.length)]
-//   return (bastionKey && bastionHost) ? {bastionHost, bastionKey} : {}
-// }
+  const bastionKey = config[`${baseName}_BASTION_KEY`]
+  const bastions = (config[`${baseName}_BASTIONS`] || '').split(',')
+  const bastionHost = bastions[Math.floor(Math.random() * bastions.length)]
+  return (bastionKey && bastionHost) ? {bastionHost, bastionKey} : {}
+}
 
-// export function getConfigs(db: ConnectionDetails) {
-//   const dbEnv: NodeJS.ProcessEnv = env(db)
-//   const dbTunnelConfig = tunnelConfig(db)
-//   if (db.bastionKey) {
-//     Object.assign(dbEnv, {
-//       PGHOST: dbTunnelConfig.localHost,
-//       PGPORT: dbTunnelConfig.localPort,
-//     })
-//   }
+export function getConfigs(db: ConnectionDetails) {
+  const dbEnv: NodeJS.ProcessEnv = env(db)
+  const dbTunnelConfig = tunnelConfig(db)
+  if (db.bastionKey) {
+    Object.assign(dbEnv, {
+      PGHOST: dbTunnelConfig.localHost,
+      PGPORT: dbTunnelConfig.localPort,
+    })
+  }
 
-//   return {
-//     dbEnv,
-//     dbTunnelConfig,
-//   }
-// }
+  return {
+    dbEnv,
+    dbTunnelConfig,
+  }
+}
 
-// export async function sshTunnel(db: ConnectionDetails, dbTunnelConfig: TunnelConfig, timeout = 10_000) {
-//   if (!db.bastionKey) {
-//     return null
-//   }
+export async function sshTunnel(db: ConnectionDetails, dbTunnelConfig: TunnelConfig, timeout = 10_000) {
+  if (!db.bastionKey) {
+    return null
+  }
 
-//   const timeoutInstance = new Timeout(timeout, 'Establishing a secure tunnel timed out')
-//   const createSSHTunnel = promisify(createTunnel.default)
-//   try {
-//     return await Promise.race([
-//       timeoutInstance.promise(),
-//       createSSHTunnel(dbTunnelConfig),
-//     ])
-//   } catch (error) {
-//     pgDebug(error)
-//     // ux.error('Unable to establish a secure tunnel to your database.')
-//   } finally {
-//     timeoutInstance.cancel()
-//   }
-// }
+  const timeoutInstance = new Timeout(timeout, 'Establishing a secure tunnel timed out')
+  const createSSHTunnel = promisify(createTunnel.default)
+  try {
+    return await Promise.race([
+      timeoutInstance.promise(),
+      createSSHTunnel(dbTunnelConfig),
+    ])
+  } catch (error) {
+    pgDebug(error)
+    ux.error('Unable to establish a secure tunnel to your database.')
+  } finally {
+    timeoutInstance.cancel()
+  }
+}
 
-// export function tunnelConfig(db: ConnectionDetails): TunnelConfig {
-//   const localHost = '127.0.0.1'
-//   const localPort = Math.floor((Math.random() * (65_535 - 49_152)) + 49_152)
-//   return {
-//     dstHost: db.host || undefined,
-//     dstPort: (db.port && Number.parseInt(db.port as string, 10)) || undefined,
-//     host: db.bastionHost,
-//     localHost,
-//     localPort,
-//     privateKey: db.bastionKey,
-//     username: 'bastion',
-//   }
-// }
+export function tunnelConfig(db: ConnectionDetails): TunnelConfig {
+  const localHost = '127.0.0.1'
+  const localPort = Math.floor((Math.random() * (65_535 - 49_152)) + 49_152)
+  return {
+    dstHost: db.host || undefined,
+    dstPort: (db.port && Number.parseInt(db.port as string, 10)) || undefined,
+    host: db.bastionHost,
+    localHost,
+    localPort,
+    privateKey: db.bastionKey,
+    username: 'bastion',
+  }
+}
 
-// class Timeout {
-//   // eslint-disable-next-line unicorn/prefer-event-target
-//   private readonly events = new EventEmitter.EventEmitter()
-//   private readonly message: string
-//   private readonly timeout: number
-//   private timer: NodeJS.Timeout | undefined
+class Timeout {
+  private readonly events = new EventEmitter.EventEmitter()
+  private readonly message: string
+  private readonly timeout: number
+  private timer: NodeJS.Timeout | undefined
 
-//   constructor(timeout: number, message: string) {
-//     this.timeout = timeout
-//     this.message = message
-//   }
+  constructor(timeout: number, message: string) {
+    this.timeout = timeout
+    this.message = message
+  }
 
-//   cancel() {
-//     this.events.emit('cancelled')
-//   }
+  cancel() {
+    this.events.emit('cancelled')
+  }
 
-//   async promise() {
-//     this.timer = setTimeout(() => {
-//       this.events.emit('error', new Error(this.message))
-//     }, this.timeout)
+  async promise() {
+    this.timer = setTimeout(() => {
+      this.events.emit('error', new Error(this.message))
+    }, this.timeout)
 
-//     try {
-//       await EventEmitter.once(this.events, 'cancelled')
-//     } finally {
-//       clearTimeout(this.timer)
-//     }
-//   }
-// }
+    try {
+      await new Promise<void>(resolve => {
+        this.events.once('cancelled', () => resolve())
+      })
+    } finally {
+      clearTimeout(this.timer)
+    }
+  }
+}

--- a/src/utils/pg/databases.ts
+++ b/src/utils/pg/databases.ts
@@ -1,166 +1,166 @@
-// import type {AddOnAttachment} from '@heroku-cli/schema'
+import type {AddOnAttachment} from '@heroku-cli/schema'
 
-// import color from '@heroku-cli/color'
-// import {APIClient} from '@heroku-cli/command'
-// import {HerokuAPIError} from '@heroku-cli/command/lib/api-client'
-// import debug from 'debug'
-// import {env} from 'node:process'
+import {color} from '@heroku-cli/color'
+import {APIClient} from '@heroku-cli/command'
+import {HerokuAPIError} from '@heroku-cli/command/lib/api-client.js'
+import debug from 'debug'
+import {env} from 'node:process'
 
-// import type {AddOnAttachmentWithConfigVarsAndPlan} from '../../types/pg/data-api'
-// import type {ConnectionDetails, ConnectionDetailsWithAttachment} from '../../types/pg/tunnel'
+import type {AddOnAttachmentWithConfigVarsAndPlan} from '../../types/pg/data-api.js'
+import type {ConnectionDetails, ConnectionDetailsWithAttachment} from '../../types/pg/tunnel.js'
 
-// import {AmbiguousError} from '../../types/errors/ambiguous'
-// import {appAttachment} from '../addons/resolve'
-// import {bastionKeyPlan, fetchConfig, getBastion} from './bastion'
-// import {getConfig, getConfigVarName, getConfigVarNameFromAttachment} from './config-vars'
+import {AmbiguousError} from '../../types/errors/ambiguous.js'
+import {appAttachment} from '../addons/resolve.js'
+import {bastionKeyPlan, fetchConfig, getBastion} from './bastion.js'
+import {getConfig, getConfigVarName, getConfigVarNameFromAttachment} from './config-vars.js'
 
-// const pgDebug = debug('pg')
+const pgDebug = debug('pg')
 
-// async function allAttachments(heroku: APIClient, appId: string): Promise<AddOnAttachmentWithConfigVarsAndPlan[]> {
-//   const {body: attachments} = await heroku.get<AddOnAttachmentWithConfigVarsAndPlan[]>(`/apps/${appId}/addon-attachments`, {
-//     headers: {'Accept-Inclusion': 'addon:plan,config_vars'},
-//   })
-//   return attachments.filter((a: AddOnAttachmentWithConfigVarsAndPlan) => a.addon.plan?.name?.startsWith('heroku-postgresql'))
-// }
+async function allAttachments(heroku: APIClient, appId: string): Promise<AddOnAttachmentWithConfigVarsAndPlan[]> {
+  const {body: attachments} = await heroku.get<AddOnAttachmentWithConfigVarsAndPlan[]>(`/apps/${appId}/addon-attachments`, {
+    headers: {'Accept-Inclusion': 'addon:plan,config_vars'},
+  })
+  return attachments.filter((a: AddOnAttachmentWithConfigVarsAndPlan) => a.addon.plan?.name?.startsWith('heroku-postgresql'))
+}
 
-// export async function getAttachment(heroku: APIClient, app: string, db = 'DATABASE_URL', namespace = ''): Promise<Required<{addon: AddOnAttachmentWithConfigVarsAndPlan} & AddOnAttachment>> {
-//   const matchesOrError = await matchesHelper(heroku, app, db, namespace)
-//   let {matches} = matchesOrError
-//   const {error} = matchesOrError
-//   // happy path where the resolver matches just one
-//   if (matches && matches.length === 1) {
-//     return matches[0] as Required<{addon: AddOnAttachmentWithConfigVarsAndPlan} & AddOnAttachment>
-//   }
+export async function getAttachment(heroku: APIClient, app: string, db = 'DATABASE_URL', namespace = ''): Promise<Required<{addon: AddOnAttachmentWithConfigVarsAndPlan} & AddOnAttachment>> {
+  const matchesOrError = await matchesHelper(heroku, app, db, namespace)
+  let {matches} = matchesOrError
+  const {error} = matchesOrError
+  // happy path where the resolver matches just one
+  if (matches && matches.length === 1) {
+    return matches[0] as Required<{addon: AddOnAttachmentWithConfigVarsAndPlan} & AddOnAttachment>
+  }
 
-//   // case for 404 where there are implicit attachments
-//   if (!matches) {
-//     const appConfigMatch = /^(.+?)::(.+)/.exec(db)
-//     if (appConfigMatch) {
-//       app = appConfigMatch[1]
-//       db = appConfigMatch[2]
-//     }
+  // case for 404 where there are implicit attachments
+  if (!matches) {
+    const appConfigMatch = /^(.+?)::(.+)/.exec(db)
+    if (appConfigMatch) {
+      app = appConfigMatch[1]
+      db = appConfigMatch[2]
+    }
 
-//     if (!db.endsWith('_URL')) {
-//       db += '_URL'
-//     }
+    if (!db.endsWith('_URL')) {
+      db += '_URL'
+    }
 
-//     const [config = {}, attachments] = await Promise.all([
-//       getConfig(heroku, app),
-//       allAttachments(heroku, app),
-//     ])
+    const [config = {}, attachments] = await Promise.all([
+      getConfig(heroku, app),
+      allAttachments(heroku, app),
+    ])
 
-//     if (attachments.length === 0) {
-//       throw new Error(`${color.app(app)} has no databases`)
-//     }
+    if (attachments.length === 0) {
+      throw new Error(`${color.app(app)} has no databases`)
+    }
 
-//     matches = attachments.filter(attachment => config[db] && config[db] === config[getConfigVarName(attachment.config_vars as string[])])
+    matches = attachments.filter(attachment => config[db] && config[db] === config[getConfigVarName(attachment.config_vars as string[])])
 
-//     if (matches.length === 0) {
-//       const validOptions = attachments.map(attachment => getConfigVarName(attachment.config_vars as string[]))
-//       throw new Error(`Unknown database: ${db}. Valid options are: ${validOptions.join(', ')}`)
-//     }
-//   }
+    if (matches.length === 0) {
+      const validOptions = attachments.map(attachment => getConfigVarName(attachment.config_vars as string[]))
+      throw new Error(`Unknown database: ${db}. Valid options are: ${validOptions.join(', ')}`)
+    }
+  }
 
-//   // case for multiple attachments with passedDb
-//   const first = matches[0] as Required<{addon: AddOnAttachmentWithConfigVarsAndPlan} & AddOnAttachment>
+  // case for multiple attachments with passedDb
+  const first = matches[0] as Required<{addon: AddOnAttachmentWithConfigVarsAndPlan} & AddOnAttachment>
 
-//   // case for 422 where there are ambiguous attachments that are equivalent
-//   if (matches.every(match => first.addon?.id === match.addon?.id && first.app?.id === match.app?.id)) {
-//     const config = await getConfig(heroku, first.app.name as string) ?? {}
-//     if (matches.every(match => config[getConfigVarName(first.addon.config_vars as string[])] === config[getConfigVarName(match.config_vars as string[])])) {
-//       return first
-//     }
-//   }
+  // case for 422 where there are ambiguous attachments that are equivalent
+  if (matches.every(match => first.addon?.id === match.addon?.id && first.app?.id === match.app?.id)) {
+    const config = await getConfig(heroku, first.app.name as string) ?? {}
+    if (matches.every(match => config[getConfigVarName(first.addon.config_vars as string[])] === config[getConfigVarName(match.config_vars as string[])])) {
+      return first
+    }
+  }
 
-//   throw error
-// }
+  throw error
+}
 
-// export const getConnectionDetails = (attachment: Required<{
-//   addon: AddOnAttachmentWithConfigVarsAndPlan
-// } & AddOnAttachment>, configVars: Record<string, string> = {}): ConnectionDetailsWithAttachment => {
-//   const connStringVar = getConfigVarNameFromAttachment(attachment, configVars)
+export const getConnectionDetails = (attachment: Required<{
+  addon: AddOnAttachmentWithConfigVarsAndPlan
+} & AddOnAttachment>, configVars: Record<string, string> = {}): ConnectionDetailsWithAttachment => {
+  const connStringVar = getConfigVarNameFromAttachment(attachment, configVars)
 
-//   // remove _URL from the end of the config var name
-//   const baseName = connStringVar.slice(0, -4)
+  // remove _URL from the end of the config var name
+  const baseName = connStringVar.slice(0, -4)
 
-//   // build the default payload for non-bastion dbs
-//   pgDebug(`Using "${connStringVar}" to connect to your database…`)
+  // build the default payload for non-bastion dbs
+  pgDebug(`Using "${connStringVar}" to connect to your database…`)
 
-//   const conn = parsePostgresConnectionString(configVars[connStringVar])
+  const conn = parsePostgresConnectionString(configVars[connStringVar])
 
-//   const payload: ConnectionDetailsWithAttachment = {
-//     attachment,
-//     database: conn.database,
-//     host: conn.host,
-//     password: conn.password,
-//     pathname: conn.pathname,
-//     port: conn.port,
-//     url: conn.url,
-//     user: conn.user,
-//   }
+  const payload: ConnectionDetailsWithAttachment = {
+    attachment,
+    database: conn.database,
+    host: conn.host,
+    password: conn.password,
+    pathname: conn.pathname,
+    port: conn.port,
+    url: conn.url,
+    user: conn.user,
+  }
 
-//   // If bastion creds exist, graft it into the payload
-//   const bastion = getBastion(configVars, baseName)
-//   if (bastion) {
-//     Object.assign(payload, bastion)
-//   }
+  // If bastion creds exist, graft it into the payload
+  const bastion = getBastion(configVars, baseName)
+  if (bastion) {
+    Object.assign(payload, bastion)
+  }
 
-//   return payload
-// }
+  return payload
+}
 
-// export async function getDatabase(heroku: APIClient, app: string, db?: string, namespace?: string) {
-//   const attached = await getAttachment(heroku, app, db, namespace)
+export async function getDatabase(heroku: APIClient, app: string, db?: string, namespace?: string) {
+  const attached = await getAttachment(heroku, app, db, namespace)
 
-//   // would inline this as well but in some cases attachment pulls down config
-//   // as well, and we would request twice at the same time but I did not want
-//   // to push this down into attachment because we do not always need config
-//   const config = await getConfig(heroku, attached.app.name as string)
+  // would inline this as well but in some cases attachment pulls down config
+  // as well, and we would request twice at the same time but I did not want
+  // to push this down into attachment because we do not always need config
+  const config = await getConfig(heroku, attached.app.name as string)
 
-//   const database = getConnectionDetails(attached, config)
-//   if (bastionKeyPlan(attached.addon) && !database.bastionKey) {
-//     const {body: bastionConfig} = await fetchConfig(heroku, attached.addon)
-//     const bastionHost = bastionConfig.host
-//     const bastionKey = bastionConfig.private_key
+  const database = getConnectionDetails(attached, config)
+  if (bastionKeyPlan(attached.addon) && !database.bastionKey) {
+    const {body: bastionConfig} = await fetchConfig(heroku, attached.addon)
+    const bastionHost = bastionConfig.host
+    const bastionKey = bastionConfig.private_key
 
-//     Object.assign(database, {bastionHost, bastionKey})
-//   }
+    Object.assign(database, {bastionHost, bastionKey})
+  }
 
-//   return database
-// }
+  return database
+}
 
-// async function matchesHelper(heroku: APIClient, app: string, db: string, namespace?: string): Promise<{error?: AmbiguousError | HerokuAPIError, matches: AddOnAttachment[] | null}> {
-//   debug(`fetching ${db} on ${app}`)
+async function matchesHelper(heroku: APIClient, app: string, db: string, namespace?: string): Promise<{error?: AmbiguousError | HerokuAPIError, matches: AddOnAttachment[] | null}> {
+  debug(`fetching ${db} on ${app}`)
 
-//   const addonService = process.env.HEROKU_POSTGRESQL_ADDON_NAME || 'heroku-postgresql'
-//   debug(`addon service: ${addonService}`)
-//   try {
-//     const attached = await appAttachment(heroku, app, db, {addon_service: addonService, namespace})
-//     return ({matches: [attached]})
-//   } catch (error) {
-//     if (error instanceof AmbiguousError && error.body?.id === 'multiple_matches' && error.matches) {
-//       return {error, matches: error.matches}
-//     }
+  const addonService = process.env.HEROKU_POSTGRESQL_ADDON_NAME || 'heroku-postgresql'
+  debug(`addon service: ${addonService}`)
+  try {
+    const attached = await appAttachment(heroku, app, db, {addon_service: addonService, namespace})
+    return ({matches: [attached]})
+  } catch (error) {
+    if (error instanceof AmbiguousError && error.body?.id === 'multiple_matches' && error.matches) {
+      return {error, matches: error.matches}
+    }
 
-//     if (error instanceof HerokuAPIError && (error as HerokuAPIError).http.statusCode === 404 && (error as HerokuAPIError).body && (error as HerokuAPIError).body.id === 'not_found') {
-//       return {error, matches: null}
-//     }
+    if (error instanceof HerokuAPIError && (error as HerokuAPIError).http.statusCode === 404 && (error as HerokuAPIError).body && (error as HerokuAPIError).body.id === 'not_found') {
+      return {error, matches: null}
+    }
 
-//     throw error
-//   }
-// }
+    throw error
+  }
+}
 
-// export const parsePostgresConnectionString = (db: string): ConnectionDetails => {
-//   const dbPath = /:\/\//.test(db) ? db : `postgres:///${db}`
-//   const url = new URL(dbPath)
-//   const {hostname, password, pathname, port, username} = url
+export const parsePostgresConnectionString = (db: string): ConnectionDetails => {
+  const dbPath = /:\/\//.test(db) ? db : `postgres:///${db}`
+  const url = new URL(dbPath)
+  const {hostname, password, pathname, port, username} = url
 
-//   return {
-//     database: pathname.charAt(0) === '/' ? pathname.slice(1) : pathname,
-//     host: hostname,
-//     password,
-//     pathname,
-//     port: port || env.PGPORT || (hostname && '5432'),
-//     url: dbPath,
-//     user: username,
-//   }
-// }
+  return {
+    database: pathname.charAt(0) === '/' ? pathname.slice(1) : pathname,
+    host: hostname,
+    password,
+    pathname,
+    port: port || env.PGPORT || (hostname && '5432'),
+    url: dbPath,
+    user: username,
+  }
+}

--- a/src/utils/pg/psql.ts
+++ b/src/utils/pg/psql.ts
@@ -1,209 +1,209 @@
-// import debug from 'debug'
-// import {
-//   type ChildProcess,
-//   type SpawnOptions,
-//   type SpawnOptionsWithStdioTuple,
-//   spawn,
-// } from 'node:child_process'
-// import {EventEmitter, once} from 'node:events'
-// import {Server} from 'node:net'
-// import {Stream} from 'node:stream'
-// import {finished} from 'node:stream/promises'
+import debug from 'debug'
+import {
+  type ChildProcess,
+  type SpawnOptions,
+  type SpawnOptionsWithStdioTuple,
+  spawn,
+} from 'node:child_process'
+import {EventEmitter, once} from 'node:events'
+import {Server} from 'node:net'
+import {Stream} from 'node:stream'
+import {finished} from 'node:stream/promises'
 
-// import {ConnectionDetails, TunnelConfig} from '../../types/pg/tunnel'
-// import {getConfigs, sshTunnel} from './bastion'
+import {ConnectionDetails, TunnelConfig} from '../../types/pg/tunnel.js'
+import {getConfigs, sshTunnel} from './bastion.js'
 
-// const pgDebug = debug('pg')
+const pgDebug = debug('pg')
 
-// export function consumeStream(inputStream: Stream) {
-//   let result = ''
-//   const throughStream = new Stream.PassThrough()
+export function consumeStream(inputStream: Stream) {
+  let result = ''
+  const throughStream = new Stream.PassThrough()
 
-//   // eslint-disable-next-line no-async-promise-executor
-//   const promise = new Promise(async (resolve, reject) => {
-//     try {
-//       await finished(throughStream)
-//       resolve(result)
-//     } catch (error) {
-//       reject(error)
-//     }
-//   })
+  // eslint-disable-next-line no-async-promise-executor
+  const promise = new Promise(async (resolve, reject) => {
+    try {
+      await finished(throughStream)
+      resolve(result)
+    } catch (error) {
+      reject(error)
+    }
+  })
 
-//   // eslint-disable-next-line no-return-assign
-//   throughStream.on('data', chunk => result += chunk.toString())
-//   inputStream.pipe(throughStream)
-//   return promise
-// }
+  // eslint-disable-next-line no-return-assign
+  throughStream.on('data', chunk => result += chunk.toString())
+  inputStream.pipe(throughStream)
+  return promise
+}
 
-// export async function exec(db: ConnectionDetails, query: string, cmdArgs: string[] = []) {
-//   const configs = getConfigs(db)
-//   const options = psqlQueryOptions(query, configs.dbEnv, cmdArgs)
-//   return runWithTunnel(db, configs.dbTunnelConfig, options)
-// }
+export async function exec(db: ConnectionDetails, query: string, cmdArgs: string[] = []) {
+  const configs = getConfigs(db)
+  const options = psqlQueryOptions(query, configs.dbEnv, cmdArgs)
+  return runWithTunnel(db, configs.dbTunnelConfig, options)
+}
 
-// export function psqlQueryOptions(query:string, dbEnv: NodeJS.ProcessEnv, cmdArgs: string[] = []) {
-//   pgDebug('Running query: %s', query.trim())
+export function psqlQueryOptions(query:string, dbEnv: NodeJS.ProcessEnv, cmdArgs: string[] = []) {
+  pgDebug('Running query: %s', query.trim())
 
-//   const psqlArgs = ['-c', query, '--set', 'sslmode=require', ...cmdArgs]
+  const psqlArgs = ['-c', query, '--set', 'sslmode=require', ...cmdArgs]
 
-//   const childProcessOptions: SpawnOptionsWithStdioTuple<'ignore', 'pipe', 'inherit'> = {
-//     stdio: ['ignore', 'pipe', 'inherit'],
-//   }
+  const childProcessOptions: SpawnOptionsWithStdioTuple<'ignore', 'pipe', 'inherit'> = {
+    stdio: ['ignore', 'pipe', 'inherit'],
+  }
 
-//   return {
-//     childProcessOptions,
-//     dbEnv,
-//     psqlArgs,
-//   }
-// }
+  return {
+    childProcessOptions,
+    dbEnv,
+    psqlArgs,
+  }
+}
 
-// export function execPSQL({childProcessOptions, dbEnv, psqlArgs}: {childProcessOptions: SpawnOptions, dbEnv: NodeJS.ProcessEnv, psqlArgs: string[]}) {
-//   const options = {
-//     env: dbEnv,
-//     ...childProcessOptions,
-//   }
+export function execPSQL({childProcessOptions, dbEnv, psqlArgs}: {childProcessOptions: SpawnOptions, dbEnv: NodeJS.ProcessEnv, psqlArgs: string[]}) {
+  const options = {
+    env: dbEnv,
+    ...childProcessOptions,
+  }
 
-//   pgDebug('opening psql process')
-//   const psql = spawn('psql', psqlArgs, options)
-//   psql.once('spawn', () => pgDebug('psql process spawned'))
+  pgDebug('opening psql process')
+  const psql = spawn('psql', psqlArgs, options)
+  psql.once('spawn', () => pgDebug('psql process spawned'))
 
-//   return psql
-// }
+  return psql
+}
 
-// // According to node.js docs, sending a kill to a process won't cause an error
-// // but could have unintended consequences if the PID gets reassigned:
-// // https://nodejs.org/docs/latest-v14.x/api/child_process.html#child_process_subprocess_kill_signal
-// // To be on the safe side, check if the process was already killed before sending the signal
-// function kill(childProcess: ChildProcess, signal: NodeJS.Signals | number | undefined) {
-//   if (!childProcess.killed) {
-//     pgDebug('killing psql child process')
-//     childProcess.kill(signal)
-//   }
-// }
+// According to node.js docs, sending a kill to a process won't cause an error
+// but could have unintended consequences if the PID gets reassigned:
+// https://nodejs.org/docs/latest-v14.x/api/child_process.html#child_process_subprocess_kill_signal
+// To be on the safe side, check if the process was already killed before sending the signal
+function kill(childProcess: ChildProcess, signal: NodeJS.Signals | number | undefined) {
+  if (!childProcess.killed) {
+    pgDebug('killing psql child process')
+    childProcess.kill(signal)
+  }
+}
 
-// export async function runWithTunnel(db: ConnectionDetails, tunnelConfig: TunnelConfig, options: Parameters<typeof execPSQL>[0]): Promise<string> {
-//   const tunnel = await Tunnel.connect(db, tunnelConfig)
-//   pgDebug('after create tunnel')
+export async function runWithTunnel(db: ConnectionDetails, tunnelConfig: TunnelConfig, options: Parameters<typeof execPSQL>[0]): Promise<string> {
+  const tunnel = await Tunnel.connect(db, tunnelConfig)
+  pgDebug('after create tunnel')
 
-//   const psql = execPSQL(options)
-//   // interactive opens with stdio: 'inherit'
-//   // which gives the child process the same stdin,stdout,stderr of the node process (global `process`)
-//   // https://nodejs.org/api/child_process.html#child_process_options_stdio
-//   // psql.stdout will be null in this case
-//   // return a string for consistency but ideally we should return the child process from this function
-//   // and let the caller decide what to do with stdin/stdout/stderr
-//   const stdoutPromise = psql.stdout ? consumeStream(psql.stdout) : Promise.resolve('')
-//   const cleanupSignalTraps = trapAndForwardSignalsToChildProcess(psql)
+  const psql = execPSQL(options)
+  // interactive opens with stdio: 'inherit'
+  // which gives the child process the same stdin,stdout,stderr of the node process (global `process`)
+  // https://nodejs.org/api/child_process.html#child_process_options_stdio
+  // psql.stdout will be null in this case
+  // return a string for consistency but ideally we should return the child process from this function
+  // and let the caller decide what to do with stdin/stdout/stderr
+  const stdoutPromise = psql.stdout ? consumeStream(psql.stdout) : Promise.resolve('')
+  const cleanupSignalTraps = trapAndForwardSignalsToChildProcess(psql)
 
-//   try {
-//     pgDebug('waiting for psql or tunnel to exit')
-//     // wait for either psql or tunnel to exit;
-//     // the important bit is that we ensure both processes are
-//     // always cleaned up in the `finally` block below
-//     await Promise.race([
-//       waitForPSQLExit(psql),
-//       tunnel.waitForClose(),
-//     ])
-//   } catch (error) {
-//     pgDebug('wait for psql or tunnel error', error)
-//     throw error
-//   } finally {
-//     pgDebug('begin tunnel cleanup')
-//     cleanupSignalTraps()
-//     tunnel.close()
-//     kill(psql, 'SIGKILL')
-//     pgDebug('end tunnel cleanup')
-//   }
+  try {
+    pgDebug('waiting for psql or tunnel to exit')
+    // wait for either psql or tunnel to exit;
+    // the important bit is that we ensure both processes are
+    // always cleaned up in the `finally` block below
+    await Promise.race([
+      waitForPSQLExit(psql),
+      tunnel.waitForClose(),
+    ])
+  } catch (error) {
+    pgDebug('wait for psql or tunnel error', error)
+    throw error
+  } finally {
+    pgDebug('begin tunnel cleanup')
+    cleanupSignalTraps()
+    tunnel.close()
+    kill(psql, 'SIGKILL')
+    pgDebug('end tunnel cleanup')
+  }
 
-//   return stdoutPromise as Promise<string>
-// }
+  return stdoutPromise as Promise<string>
+}
 
-// // trap SIGINT so that ctrl+c can be used by psql without killing the
-// // parent node process.
-// // you can use ctrl+c in psql to kill running queries
-// // while keeping the psql process open.
-// // This code is to stop the parent node process (heroku CLI)
-// // from exiting. If the parent Heroku CLI node process exits, then psql will exit as it
-// // is a child process of the Heroku CLI node process.
-// export const trapAndForwardSignalsToChildProcess = (childProcess: ChildProcess) => {
-//   const signalsToTrap: NodeJS.Signals[] = ['SIGINT']
-//   const signalTraps = signalsToTrap.map(signal => {
-//     process.removeAllListeners(signal)
-//     const listener = () => kill(childProcess, signal)
-//     process.on(signal, listener)
-//     return [signal, listener]
-//   }) as ([NodeJS.Signals, () => void])[]
+// trap SIGINT so that ctrl+c can be used by psql without killing the
+// parent node process.
+// you can use ctrl+c in psql to kill running queries
+// while keeping the psql process open.
+// This code is to stop the parent node process (heroku CLI)
+// from exiting. If the parent Heroku CLI node process exits, then psql will exit as it
+// is a child process of the Heroku CLI node process.
+export const trapAndForwardSignalsToChildProcess = (childProcess: ChildProcess) => {
+  const signalsToTrap: NodeJS.Signals[] = ['SIGINT']
+  const signalTraps = signalsToTrap.map(signal => {
+    process.removeAllListeners(signal)
+    const listener = () => kill(childProcess, signal)
+    process.on(signal, listener)
+    return [signal, listener]
+  }) as ([NodeJS.Signals, () => void])[]
 
-//   // restores the built-in node ctrl+c and other handlers
-//   return () => {
-//     for (const [signal, listener] of signalTraps) {
-//       process.removeListener(signal as string, listener)
-//     }
-//   }
-// }
+  // restores the built-in node ctrl+c and other handlers
+  return () => {
+    for (const [signal, listener] of signalTraps) {
+      process.removeListener(signal as string, listener)
+    }
+  }
+}
 
-// export async function waitForPSQLExit(psql: EventEmitter) {
-//   let errorToThrow: Error | null = null
-//   try {
-//     const [exitCode] = await once(psql, 'close')
+export async function waitForPSQLExit(psql: EventEmitter) {
+  let errorToThrow: Error | null = null
+  try {
+    const [exitCode] = await once(psql, 'close')
 
-//     pgDebug(`psql exited with code ${exitCode}`)
-//     if (exitCode > 0) {
-//       errorToThrow = new Error(`psql exited with code ${exitCode}`)
-//     }
-//   } catch (error) {
-//     pgDebug('psql process error', error)
-//     const {code} = error as {code: string}
-//     if (code === 'ENOENT') {
-//       errorToThrow = new Error('The local psql command could not be located. For help installing psql, see https://devcenter.heroku.com/articles/heroku-postgresql#local-setup')
-//     }
-//   }
+    pgDebug(`psql exited with code ${exitCode}`)
+    if (exitCode > 0) {
+      errorToThrow = new Error(`psql exited with code ${exitCode}`)
+    }
+  } catch (error) {
+    pgDebug('psql process error', error)
+    const {code} = error as {code: string}
+    if (code === 'ENOENT') {
+      errorToThrow = new Error('The local psql command could not be located. For help installing psql, see https://devcenter.heroku.com/articles/heroku-postgresql#local-setup')
+    }
+  }
 
-//   if (errorToThrow) {
-//     throw errorToThrow
-//   }
-// }
+  if (errorToThrow) {
+    throw errorToThrow
+  }
+}
 
-// // a small wrapper around tunnel-ssh
-// // so that other code doesn't have to worry about
-// // whether there is or is not a tunnel
-// export class Tunnel {
-//   private readonly bastionTunnel: Server
-//   private readonly events: EventEmitter
-//   constructor(bastionTunnel: Server) {
-//     this.bastionTunnel = bastionTunnel
-//     // eslint-disable-next-line unicorn/prefer-event-target
-//     this.events = new EventEmitter()
-//   }
+// a small wrapper around tunnel-ssh
+// so that other code doesn't have to worry about
+// whether there is or is not a tunnel
+export class Tunnel {
+  private readonly bastionTunnel: Server
+  private readonly events: EventEmitter
+  constructor(bastionTunnel: Server) {
+    this.bastionTunnel = bastionTunnel
+    // eslint-disable-next-line unicorn/prefer-event-target
+    this.events = new EventEmitter()
+  }
 
-//   static async connect(db: ConnectionDetails, tunnelConfig: TunnelConfig) {
-//     const tunnel = await sshTunnel(db, tunnelConfig)
-//     return new Tunnel(tunnel as Server)
-//   }
+  static async connect(db: ConnectionDetails, tunnelConfig: TunnelConfig) {
+    const tunnel = await sshTunnel(db, tunnelConfig)
+    return new Tunnel(tunnel as Server)
+  }
 
-//   close() {
-//     if (this.bastionTunnel) {
-//       pgDebug('close tunnel')
-//       this.bastionTunnel.close()
-//     } else {
-//       pgDebug('no tunnel necessary; sending fake close event')
-//       this.events.emit('close', 0)
-//     }
-//   }
+  close() {
+    if (this.bastionTunnel) {
+      pgDebug('close tunnel')
+      this.bastionTunnel.close()
+    } else {
+      pgDebug('no tunnel necessary; sending fake close event')
+      this.events.emit('close', 0)
+    }
+  }
 
-//   async waitForClose() {
-//     if (this.bastionTunnel) {
-//       try {
-//         pgDebug('wait for tunnel close')
-//         await once(this.bastionTunnel, 'close')
-//         pgDebug('tunnel closed')
-//       } catch (error) {
-//         pgDebug('tunnel close error', error)
-//         throw new Error('Secure tunnel to your database failed')
-//       }
-//     } else {
-//       pgDebug('no bastion required; waiting for fake close event')
-//       await once(this.events, 'close')
-//     }
-//   }
-// }
+  async waitForClose() {
+    if (this.bastionTunnel) {
+      try {
+        pgDebug('wait for tunnel close')
+        await once(this.bastionTunnel, 'close')
+        pgDebug('tunnel closed')
+      } catch (error) {
+        pgDebug('tunnel close error', error)
+        throw new Error('Secure tunnel to your database failed')
+      }
+    } else {
+      pgDebug('no bastion required; waiting for fake close event')
+      await once(this.events, 'close')
+    }
+  }
+}

--- a/src/ux/prompt.ts
+++ b/src/ux/prompt.ts
@@ -1,11 +1,17 @@
 import inquirer from 'inquirer'
 
-export async function prompt(name: string, options?: {default?: string; required?: boolean; type?: string}): Promise<string> {
+type PromptOptions = {
+  default?: string
+  required?: boolean
+  type?: string
+}
+
+export async function prompt(name: string, options?: PromptOptions): Promise<string> {
   const {answer} = await (inquirer as any).prompt([{
     default: options?.default,
     message: name,
     name: 'answer',
-    type: 'input',
+    type: options?.type ?? 'input',
     validate: options?.required ? (input: string) => input.length > 0 || 'This field is required' : undefined,
   }])
   return answer

--- a/src/ux/prompt.ts
+++ b/src/ux/prompt.ts
@@ -1,8 +1,12 @@
-// import {ux} from '@oclif/core'
+import inquirer from 'inquirer'
 
-// export async function prompt(name: string, options?: ux.IPromptOptions): Promise<string> {
-//   return ux.prompt(name, options)
-// }
-
-// Temporarily disabled UX functions
-export const disabled = true
+export async function prompt(name: string, options?: {default?: string; required?: boolean; type?: string}): Promise<string> {
+  const {answer} = await (inquirer as any).prompt([{
+    default: options?.default,
+    message: name,
+    name: 'answer',
+    type: 'input',
+    validate: options?.required ? (input: string) => input.length > 0 || 'This field is required' : undefined,
+  }])
+  return answer
+}

--- a/src/ux/wait.ts
+++ b/src/ux/wait.ts
@@ -1,8 +1,5 @@
-// import {ux} from '@oclif/core'
-
-// export function wait(ms?: number): Promise<void> {
-//   return ux.wait(ms)
-// }
-
-// Temporarily disabled UX functions
-export const disabled = true
+export function wait(ms?: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -1,15 +1,14 @@
-import {stderr, stdout} from 'stdout-stderr'
+import {initCliTest, restoreStdoutStderr, setupStdoutStderr} from '@heroku-cli/test-utils'
 
 export const mochaHooks = {
   afterEach(done: () => void) {
-    stdout.stop()
-    stderr.stop()
+    restoreStdoutStderr()
     done()
   },
 
   beforeEach(done: () => void) {
-    stdout.start()
-    stderr.start()
+    initCliTest()
+    setupStdoutStderr()
     done()
   },
 }

--- a/test/unit/utils/addons/resolve.test.ts
+++ b/test/unit/utils/addons/resolve.test.ts
@@ -1,77 +1,76 @@
-/* eslint-disable unicorn/no-empty-file */
-// import {APIClient} from '@heroku-cli/command'
-// import {Config} from '@oclif/core'
-// import * as chai from 'chai'
-// import chaiAsPromised from 'chai-as-promised'
-// import * as nock from 'nock'
+import {APIClient} from '@heroku-cli/command'
+import {Config} from '@oclif/core'
+import * as chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import nock from 'nock'
 
-// import {AmbiguousError} from '../../../../src/types/errors/ambiguous'
-// import {NotFound} from '../../../../src/types/errors/not-found'
-// import {appAttachment} from '../../../../src/utils/addons/resolve'
+import {AmbiguousError} from '../../../../src/types/errors/ambiguous.js'
+import {NotFound} from '../../../../src/types/errors/not-found.js'
+import {appAttachment} from '../../../../src/utils/addons/resolve.js'
 
-// const {expect} = chai
+const {expect} = chai
 
-// chai.use(chaiAsPromised)
+chai.use(chaiAsPromised)
 
-// describe('appAttachment', function () {
-//   let config: Config
-//   let heroku: APIClient
-//   const HEROKU_API = 'https://api.heroku.com'
-//   const sampleAddon = {
-//     addon: {
-//       config_vars: [],
-//       id: 'addon-1',
-//       name: 'test-addon',
-//       plan: {},
-//     },
-//     name: 'attachment-1',
-//     namespace: null,
-//   }
+describe('appAttachment', function () {
+  let config: Config
+  let heroku: APIClient
+  const HEROKU_API = 'https://api.heroku.com'
+  const sampleAddon = {
+    addon: {
+      config_vars: [],
+      id: 'addon-1',
+      name: 'test-addon',
+      plan: {},
+    },
+    name: 'attachment-1',
+    namespace: null,
+  }
 
-//   beforeEach(async function () {
-//     config = await Config.load()
-//     heroku = new APIClient(config)
-//   })
+  beforeEach(async function () {
+    config = await Config.load()
+    heroku = new APIClient(config)
+  })
 
-//   afterEach(function () {
-//     nock.cleanAll()
-//   })
+  afterEach(function () {
+    nock.cleanAll()
+  })
 
-//   it('returns the resolved addon attachment when one match', async function () {
-//     nock(HEROKU_API)
-//       .post('/actions/addon-attachments/resolve')
-//       .reply(200, [sampleAddon])
-//     const result = await appAttachment(heroku, 'my-app', 'attachment-1')
-//     expect(result).to.deep.equal(sampleAddon)
-//   })
+  it('returns the resolved addon attachment when one match', async function () {
+    nock(HEROKU_API)
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [sampleAddon])
+    const result = await appAttachment(heroku, 'my-app', 'attachment-1')
+    expect(result).to.deep.equal(sampleAddon)
+  })
 
-//   it('throws NotFound when no matches', async function () {
-//     nock(HEROKU_API)
-//       .post('/actions/addon-attachments/resolve')
-//       .reply(200, [])
-//     await expect(appAttachment(heroku, 'my-app', 'missing')).to.be.rejectedWith(NotFound)
-//   })
+  it('throws NotFound when no matches', async function () {
+    nock(HEROKU_API)
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [])
+    await expect(appAttachment(heroku, 'my-app', 'missing')).to.be.rejectedWith(NotFound)
+  })
 
-//   it('throws AmbiguousError when multiple matches and no namespace', async function () {
-//     const ambiguous = [
-//       {...sampleAddon, namespace: null},
-//       {...sampleAddon, name: 'other', namespace: null},
-//     ]
-//     nock(HEROKU_API)
-//       .post('/actions/addon-attachments/resolve')
-//       .reply(200, ambiguous)
-//     await expect(appAttachment(heroku, 'my-app', 'ambiguous')).to.be.rejectedWith(AmbiguousError)
-//   })
+  it('throws AmbiguousError when multiple matches and no namespace', async function () {
+    const ambiguous = [
+      {...sampleAddon, namespace: null},
+      {...sampleAddon, name: 'other', namespace: null},
+    ]
+    nock(HEROKU_API)
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, ambiguous)
+    await expect(appAttachment(heroku, 'my-app', 'ambiguous')).to.be.rejectedWith(AmbiguousError)
+  })
 
-//   it('filters by namespace if provided', async function () {
-//     const ambiguous = [
-//       {...sampleAddon, namespace: 'foo'},
-//       {...sampleAddon, namespace: 'bar'},
-//     ]
-//     nock(HEROKU_API)
-//       .post('/actions/addon-attachments/resolve')
-//       .reply(200, ambiguous)
-//     const result = await appAttachment(heroku, 'my-app', 'attachment-1', {namespace: 'foo'})
-//     expect(result.namespace).to.equal('foo')
-//   })
-// })
+  it('filters by namespace if provided', async function () {
+    const ambiguous = [
+      {...sampleAddon, namespace: 'foo'},
+      {...sampleAddon, namespace: 'bar'},
+    ]
+    nock(HEROKU_API)
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, ambiguous)
+    const result = await appAttachment(heroku, 'my-app', 'attachment-1', {namespace: 'foo'})
+    expect(result.namespace).to.equal('foo')
+  })
+})

--- a/test/unit/utils/pg/databases.test.ts
+++ b/test/unit/utils/pg/databases.test.ts
@@ -1,53 +1,53 @@
-// import type {APIClient} from '@heroku-cli/command'
+import type {APIClient} from '@heroku-cli/command'
 
-// import {expect} from 'chai'
-// import * as sinon from 'sinon'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
 
-// import * as resolve from '../../../../src/utils/addons/resolve'
-// import * as configVars from '../../../../src/utils/pg/config-vars'
-// import {getDatabase} from '../../../../src/utils/pg/databases'
+import * as resolve from '../../../../src/utils/addons/resolve.js'
+import * as configVars from '../../../../src/utils/pg/config-vars.js'
+import {getDatabase} from '../../../../src/utils/pg/databases.js'
 
-// const mockHeroku = {} as APIClient
-// const mockAttachment = {
-//   addon: {
-//     addon: {id: 'addon-id', plan: {name: 'heroku-postgresql:standard-0'}},
-//     config_vars: ['DATABASE_URL'],
-//     id: 'addon-id',
-//     plan: {name: 'heroku-postgresql:standard-0'},
-//   },
-//   app: {name: 'test-app'},
-//   config_vars: ['DATABASE_URL'],
-// }
-// const mockConfig = {
-//   DATABASE_URL: 'postgres://user:pass@localhost:5432/dbname',
-// }
+const mockHeroku = {} as APIClient
+const mockAttachment = {
+  addon: {
+    addon: {id: 'addon-id', plan: {name: 'heroku-postgresql:standard-0'}},
+    config_vars: ['DATABASE_URL'],
+    id: 'addon-id',
+    plan: {name: 'heroku-postgresql:standard-0'},
+  },
+  app: {name: 'test-app'},
+  config_vars: ['DATABASE_URL'],
+}
+const mockConfig = {
+  DATABASE_URL: 'postgres://user:pass@localhost:5432/dbname',
+}
 
-// describe.skip('getDatabase', function () {
-//   let appAttachmentStub: sinon.SinonStub
-//   let getConfigStub: sinon.SinonStub
+describe('getDatabase', function () {
+  let appAttachmentStub: sinon.SinonStub
+  let getConfigStub: sinon.SinonStub
 
-//   before(function () {
-//     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-//     appAttachmentStub = sinon.stub(resolve, 'appAttachment').resolves(mockAttachment as any)
-//     getConfigStub = sinon.stub(configVars, 'getConfig').resolves(mockConfig)
-//   })
+  before(function () {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    appAttachmentStub = sinon.stub(resolve, 'appAttachment').resolves(mockAttachment as any)
+    getConfigStub = sinon.stub(configVars, 'getConfig').resolves(mockConfig)
+  })
 
-//   after(function () {
-//     appAttachmentStub.restore()
-//     getConfigStub.restore()
-//   })
+  after(function () {
+    appAttachmentStub.restore()
+    getConfigStub.restore()
+  })
 
-//   it('returns connection details for a valid attachment', async function () {
-//     const result = await getDatabase(mockHeroku, 'test-app', 'DATABASE_URL')
-//     expect(result).to.deep.equal({
-//       attachment: mockAttachment,
-//       database: 'dbname',
-//       host: 'localhost',
-//       password: 'pass',
-//       pathname: '/dbname',
-//       port: '5432',
-//       url: 'postgres://user:pass@localhost:5432/dbname',
-//       user: 'user',
-//     })
-//   })
-// })
+  it('returns connection details for a valid attachment', async function () {
+    const result = await getDatabase(mockHeroku, 'test-app', 'DATABASE_URL')
+    expect(result).to.deep.equal({
+      attachment: mockAttachment,
+      database: 'dbname',
+      host: 'localhost',
+      password: 'pass',
+      pathname: '/dbname',
+      port: '5432',
+      url: 'postgres://user:pass@localhost:5432/dbname',
+      user: 'user',
+    })
+  })
+})

--- a/test/unit/utils/pg/databases.test.ts
+++ b/test/unit/utils/pg/databases.test.ts
@@ -1,44 +1,92 @@
-import type {APIClient} from '@heroku-cli/command'
+import type {AddOnAttachment} from '@heroku-cli/schema'
 
+import {APIClient} from '@heroku-cli/command'
+import {Config} from '@oclif/core'
 import {expect} from 'chai'
-import * as sinon from 'sinon'
+import nock from 'nock'
 
-import * as resolve from '../../../../src/utils/addons/resolve.js'
-import * as configVars from '../../../../src/utils/pg/config-vars.js'
+import type {AddOnAttachmentWithConfigVarsAndPlan} from '../../../../src/types/pg/data-api.js'
+
 import {getDatabase} from '../../../../src/utils/pg/databases.js'
 
-const mockHeroku = {} as APIClient
+const HEROKU_API = 'https://api.heroku.com'
+const plan = {
+  addon_service: {id: 'postgres', name: 'heroku-postgresql'},
+  created_at: '2024-01-01T00:00:00Z',
+  default: false,
+  description: 'Standard 0',
+  id: 'plan-id',
+  name: 'heroku-postgresql:standard-0',
+  price: {cents: 0, unit: 'month'},
+  space: null,
+  state: 'public',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
 const mockAttachment = {
   addon: {
-    addon: {id: 'addon-id', plan: {name: 'heroku-postgresql:standard-0'}},
+    addon: {
+      addon_service: {id: 'postgres', name: 'heroku-postgresql'},
+      app: {id: 'app-id', name: 'test-app'},
+      config_vars: ['DATABASE_URL'],
+      id: 'addon-id',
+      name: 'heroku-postgresql',
+      plan,
+    },
+    addon_service: {id: 'postgres', name: 'heroku-postgresql'},
+    app: {id: 'app-id', name: 'test-app'},
     config_vars: ['DATABASE_URL'],
+    created_at: '2024-01-01T00:00:00Z',
     id: 'addon-id',
-    plan: {name: 'heroku-postgresql:standard-0'},
+    log_input_url: 'https://log-input-url.com',
+    name: 'heroku-postgresql',
+    namespace: null,
+    plan,
+    updated_at: '2024-01-01T00:00:00Z',
+    web_url: 'https://web-url.com',
   },
-  app: {name: 'test-app'},
+  app: {id: 'app-id', name: 'test-app'},
   config_vars: ['DATABASE_URL'],
-}
+  created_at: '2024-01-01T00:00:00Z',
+  id: 'attachment-id',
+  name: 'DATABASE',
+  namespace: null,
+  plan,
+  updated_at: '2024-01-01T00:00:00Z',
+} as { addon: AddOnAttachmentWithConfigVarsAndPlan } & AddOnAttachment
+
+// Add a runtime assertion to ensure plan exists
+if (!mockAttachment.addon.addon?.plan) throw new Error('mockAttachment.addon.addon.plan is missing')
+
 const mockConfig = {
   DATABASE_URL: 'postgres://user:pass@localhost:5432/dbname',
 }
 
 describe('getDatabase', function () {
-  let appAttachmentStub: sinon.SinonStub
-  let getConfigStub: sinon.SinonStub
+  let config: Config
+  let heroku: APIClient
 
-  before(function () {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    appAttachmentStub = sinon.stub(resolve, 'appAttachment').resolves(mockAttachment as any)
-    getConfigStub = sinon.stub(configVars, 'getConfig').resolves(mockConfig)
+  beforeEach(async function () {
+    config = await Config.load()
+    heroku = new APIClient(config)
   })
 
-  after(function () {
-    appAttachmentStub.restore()
-    getConfigStub.restore()
+  afterEach(function () {
+    nock.cleanAll()
   })
 
   it('returns connection details for a valid attachment', async function () {
-    const result = await getDatabase(mockHeroku, 'test-app', 'DATABASE_URL')
+    nock(HEROKU_API)
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [mockAttachment])
+    nock(HEROKU_API)
+      .get('/apps/test-app/config-vars')
+      .reply(200, mockConfig)
+
+    // Debug log to inspect the object passed to bastionKeyPlan
+    console.log('DEBUG attached.addon:', mockAttachment.addon)
+
+    const result = await getDatabase(heroku, 'test-app', 'DATABASE_URL')
     expect(result).to.deep.equal({
       attachment: mockAttachment,
       database: 'dbname',

--- a/test/unit/ux/confirm.test.ts
+++ b/test/unit/ux/confirm.test.ts
@@ -1,6 +1,6 @@
+import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
 import {stdin as mockStdin} from 'mock-stdin'
-import {stdout} from 'stdout-stderr'
 import stripAnsi from 'strip-ansi'
 
 import {confirm} from '../../../src/ux/confirm.js'
@@ -25,7 +25,7 @@ describe('confirm', function () {
     await wait(2000)
     stdin.send('y\n')
     const result = await confirmPromise
-    const output = stripAnsi(stdout.output)
+    const output = stripAnsi(stdout())
     expect(output).to.contain('Are you sure')
     expect(result).to.equal(true)
   })
@@ -35,7 +35,7 @@ describe('confirm', function () {
     await wait(2000)
     stdin.send('n\n')
     const result = await confirmPromise
-    const output = stripAnsi(stdout.output)
+    const output = stripAnsi(stdout())
     expect(output).to.contain('Are you sure')
     expect(result).to.equal(false)
   })
@@ -44,7 +44,7 @@ describe('confirm', function () {
     const confirmPromise = confirm('Are you sure', {ms: 1000})
     await wait(2000) // Wait longer than the timeout
     const result = await confirmPromise
-    const output = stripAnsi(stdout.output)
+    const output = stripAnsi(stdout())
     expect(output).to.contain('Are you sure')
     expect(result).to.equal(false) // Default answer is false
   })
@@ -53,7 +53,7 @@ describe('confirm', function () {
     const confirmPromise = confirm('Are you sure', {defaultAnswer: true, ms: 1000})
     await wait(2000) // Wait longer than the timeout
     const result = await confirmPromise
-    const output = stripAnsi(stdout.output)
+    const output = stripAnsi(stdout())
     expect(output).to.contain('Are you sure')
     expect(result).to.equal(true) // Custom default answer is true
   })

--- a/test/unit/ux/prompt.test.ts
+++ b/test/unit/ux/prompt.test.ts
@@ -1,31 +1,28 @@
-// import {expect} from 'chai'
-import * as sinon from 'sinon'
+import {expect} from 'chai'
+import {stdin as mockStdin} from 'mock-stdin'
+import {stdout} from 'stdout-stderr'
+import stripAnsi from 'strip-ansi'
 
-// import expectOutput from '../../../src/test-helpers/expect-output'
-// import {stderr} from '../../../src/test-helpers/stub-output'
-// import {prompt} from '../../../src/ux/prompt'
+import {prompt} from '../../../src/ux/prompt.js'
 
-// import stripAnsi = require('strip-ansi');
-
-describe.skip('prompt', function () {
-  let stdinStub: sinon.SinonStub
+describe('prompt', function () {
+  let stdin: ReturnType<typeof mockStdin>
 
   beforeEach(function () {
-    stdinStub = sinon.stub(process.stdin, 'once')
+    stdin = mockStdin()
   })
 
   afterEach(function () {
-    stdinStub.restore()
+    stdin.restore()
   })
 
   it('should print the prompt and return the entered value', async function () {
-    stdinStub.callsFake((event, cb) => {
-      if (event === 'data') cb('test-value\n')
-      return process.stdin
-    })
-    // const result = await prompt('Enter something')
-    // const output = stripAnsi(stderr())
-    // expectOutput(output, 'Enter something:')
-    // expect(result).to.equal('test-value')
+    setTimeout(() => {
+      stdin.send('test-value\n')
+    }, 10)
+    const result = await prompt('Enter something')
+    const output = stripAnsi(stdout.output)
+    expect(output).to.include('Enter something')
+    expect(result).to.equal('test-value')
   })
 })

--- a/test/unit/ux/prompt.test.ts
+++ b/test/unit/ux/prompt.test.ts
@@ -1,6 +1,6 @@
+import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
 import {stdin as mockStdin} from 'mock-stdin'
-import {stdout} from 'stdout-stderr'
 import stripAnsi from 'strip-ansi'
 
 import {prompt} from '../../../src/ux/prompt.js'
@@ -21,7 +21,7 @@ describe('prompt', function () {
       stdin.send('test-value\n')
     }, 10)
     const result = await prompt('Enter something')
-    const output = stripAnsi(stdout.output)
+    const output = stripAnsi(stdout())
     expect(output).to.include('Enter something')
     expect(result).to.equal('test-value')
   })

--- a/test/unit/ux/styled-header.test.ts
+++ b/test/unit/ux/styled-header.test.ts
@@ -1,5 +1,5 @@
+import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
-import {stdout} from 'stdout-stderr'
 import stripAnsi from 'strip-ansi'
 
 import {styledHeader} from '../../../src/ux/styled-header.js'
@@ -8,7 +8,7 @@ describe('styledHeader', function () {
   it('should print the correct styled header output', function () {
     const header = 'My Test Header'
     styledHeader(header)
-    const actual = stripAnsi(stdout.output)
+    const actual = stripAnsi(stdout())
     expect(actual).to.equal('=== My Test Header\n\n')
   })
 })

--- a/test/unit/ux/styled-json.test.ts
+++ b/test/unit/ux/styled-json.test.ts
@@ -1,5 +1,5 @@
+import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
-import {stdout} from 'stdout-stderr'
 import tsheredoc from 'tsheredoc'
 const heredoc = tsheredoc.default
 
@@ -20,7 +20,7 @@ describe('styledJSON', function () {
         }
       }
     `)
-    const actual = stripAnsi(stdout.output)
+    const actual = stripAnsi(stdout())
     expect(actual).to.equal(expected)
   })
 })

--- a/test/unit/ux/styled-object.test.ts
+++ b/test/unit/ux/styled-object.test.ts
@@ -1,5 +1,5 @@
+import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
-import {stdout} from 'stdout-stderr'
 import tsheredoc from 'tsheredoc'
 const heredoc = tsheredoc.default
 import {styledObject} from '../../../src/ux/styled-object.js'
@@ -14,7 +14,7 @@ describe('styledObject', function () {
       baz: 42
       foo: bar
     `)
-    const actual = stripAnsi(stdout.output)
+    const actual = stripAnsi(stdout())
     expect(actual).to.equal(expected)
   })
 })

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -1,9 +1,11 @@
+import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
-import {stdout} from 'stdout-stderr'
 
 import {table} from '../../../src/ux/table.js'
 
-const removeAllWhitespace = (str: string): string => str.replace(/\s+/g, '')
+import stripAnsi = require('strip-ansi')
+
+const removeAllWhitespace = (str: string): string => stripAnsi(str).replace(/\s+/g, '')
 
 describe('table', function () {
   it('should print the correct table output', function () {
@@ -14,8 +16,8 @@ describe('table', function () {
     const columns = {baz: {header: 'Baz'}, foo: {header: 'Foo'}}
     table(data, columns)
 
-    expect(removeAllWhitespace(stdout.output)).to.include(removeAllWhitespace('Baz   Foo'))
-    expect(removeAllWhitespace(stdout.output)).to.include(removeAllWhitespace('42    bar'))
-    expect(removeAllWhitespace(stdout.output)).to.include(removeAllWhitespace('7     qux'))
+    expect(removeAllWhitespace(stdout())).to.include(removeAllWhitespace('Baz   Foo'))
+    expect(removeAllWhitespace(stdout())).to.include(removeAllWhitespace('42    bar'))
+    expect(removeAllWhitespace(stdout())).to.include(removeAllWhitespace('7     qux'))
   })
 })

--- a/test/unit/ux/wait.test.ts
+++ b/test/unit/ux/wait.test.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai'
 
-// import {wait} from '../../../src/ux/wait.js'
+import {wait} from '../../../src/ux/wait.js'
 
-describe.skip('wait', function () {
+describe('wait', function () {
   it('should actually wait for at least the specified period of time', async function () {
     const duration = 200
     const start = Date.now()
-    // await wait(duration)
+    await wait(duration)
     const elapsed = Date.now() - start
     // Allow a small margin for timing inaccuracy
     expect(elapsed).to.be.at.least(duration - 20)


### PR DESCRIPTION
[W-18293732](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002CuL84YAF/view)
[W-18293738](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002CuOf7YAF/view)

### Description

This reimplements wait and prompt without oclif 2's ux functions. it also uncomments and fixes pg utilities.


### Testing

1. Pull down branch and `npm run build`
2. `npm run example prompt-command`