### PR TITLE
feat: add oclif table options

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -8,4 +8,4 @@
   "reporter": "spec",
   "timeout": 15000,
   "node-option": ["loader=ts-node/esm"]
-} 
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heroku/heroku-cli-util",
-  "version": "9.0.2",
+  "version": "10.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heroku/heroku-cli-util",
-      "version": "9.0.2",
+      "version": "10.0.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/color": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@heroku/heroku-cli-util",
-  "version": "10.0.0-beta.1",
+  "version": "9.0.2",
   "description": "Set of helpful CLI utilities",
   "author": "Heroku",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@heroku/heroku-cli-util",
-  "version": "9.0.2",
+  "version": "10.0.0-beta.1",
   "description": "Set of helpful CLI utilities",
   "author": "Heroku",
   "license": "ISC",

--- a/src/ux/styled-object.ts
+++ b/src/ux/styled-object.ts
@@ -27,7 +27,7 @@ export function styledObject(obj: unknown, keys?: string[]) {
   const maxKeyLength = Math.max(...keyLengths) + 2
 
   const logKeyValue = (key: string, value: unknown): string =>
-    `${color.cyan(key)}:` + ' '.repeat(maxKeyLength - key.length - 1) + prettyPrint(value)
+    `${color.rgb(147, 112, 219)(key)}:` + ' '.repeat(maxKeyLength - key.length - 1) + prettyPrint(value)
 
   for (const [key, value] of Object.entries(obj)) {
     if (keys && !keys.includes(key)) continue

--- a/src/ux/table.ts
+++ b/src/ux/table.ts
@@ -1,4 +1,4 @@
-import {printTable} from '@oclif/table'
+import {TableOptions, printTable} from '@oclif/table'
 
 type Column<T extends Record<string, unknown>> = {
   extended: boolean;
@@ -9,22 +9,10 @@ type Column<T extends Record<string, unknown>> = {
 
 type Columns<T extends Record<string, unknown>> = { [key: string]: Partial<Column<T>> };
 
-type Options = {
-  columns?: string;
-  extended?: boolean;
-  filter?: string;
-  'no-header'?: boolean;
-  'no-truncate'?: boolean;
-  printLine?(s: unknown): void;
-  rowStart?: string;
-  sort?: string;
-  title?: string;
-}
-
 export function table<T extends Record<string, unknown>>(
   data: T[],
   columns: Columns<T>,
-  options?: Options,
+  options?: { printLine?(s: unknown): void } & Omit<TableOptions<T>, 'columns' | 'data'>,
 ) {
   const cols = Object.entries(columns).map(([key, opts]) => {
     if (opts.header) return {key, name: opts.header}
@@ -34,10 +22,19 @@ export function table<T extends Record<string, unknown>>(
     Object.fromEntries(Object.entries(columns).map(([key, {get}]) => [key, get ? get(row) : row[key]])),
   ) as Array<Record<string, unknown>>
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const {printLine, ...tableOptions} = options || {}
+
   printTable({
-    borderStyle: 'headers-only-with-underline',
+    ...(tableOptions?.noStyle ? {} : {
+      borderColor: 'whiteBright',
+      borderStyle: 'headers-only-with-underline',
+      headerOptions: {
+        color: 'rgb(147, 112, 219)',
+      },
+    }),
+    ...tableOptions,
     columns: cols,
-    data: d,
-    title: options?.title,
+    data: d as T[],
   })
 }

--- a/test/unit/ux/styled-json.test.ts
+++ b/test/unit/ux/styled-json.test.ts
@@ -1,11 +1,10 @@
 import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
+import stripAnsi from 'strip-ansi'
 import tsheredoc from 'tsheredoc'
 const heredoc = tsheredoc.default
 
 import {styledJSON} from '../../../src/ux/styled-json.js'
-
-import stripAnsi = require('strip-ansi')
 
 describe('styledJSON', function () {
   it('should print the correct styled object output', function () {

--- a/test/unit/ux/styled-object.test.ts
+++ b/test/unit/ux/styled-object.test.ts
@@ -1,10 +1,9 @@
 import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
+import stripAnsi from 'strip-ansi'
 import tsheredoc from 'tsheredoc'
 const heredoc = tsheredoc.default
 import {styledObject} from '../../../src/ux/styled-object.js'
-
-import stripAnsi = require('strip-ansi')
 
 describe('styledObject', function () {
   it('should print the correct styled object output', function () {

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -45,9 +45,6 @@ describe('table', function () {
     const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
     table(data, columns)
     const output = stdout()
-    // Should have headers-only-with-underline border style
-    expect(output).to.include('─')
-    expect(output).to.include('│')
     // Should have whiteBright border color
     expect(output).to.include('\u001B[97m') // ANSI code for whiteBright
     // Should have purple headers

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -1,9 +1,8 @@
 import {stdout} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
+import stripAnsi from 'strip-ansi'
 
 import {table} from '../../../src/ux/table.js'
-
-import stripAnsi = require('strip-ansi')
 
 const removeAllWhitespace = (str: string): string => stripAnsi(str).replace(/\s+/g, '')
 

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -14,8 +14,7 @@ describe('table', function () {
       {baz: 7, foo: 'qux'},
     ]
     const columns = {baz: {header: 'Baz'}, foo: {header: 'Foo'}}
-    table(data, columns)
-
+    table(data, columns, {noStyle: true})
     expect(removeAllWhitespace(stdout())).to.include(removeAllWhitespace('Baz   Foo'))
     expect(removeAllWhitespace(stdout())).to.include(removeAllWhitespace('42    bar'))
     expect(removeAllWhitespace(stdout())).to.include(removeAllWhitespace('7     qux'))

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -18,4 +18,42 @@ describe('table', function () {
     expect(removeAllWhitespace(stdout())).to.include(removeAllWhitespace('42    bar'))
     expect(removeAllWhitespace(stdout())).to.include(removeAllWhitespace('7     qux'))
   })
+
+  it('should respect sort options', function () {
+    const data = [
+      {age: 30, name: 'Alice'},
+      {age: 25, name: 'Bob'},
+      {age: 35, name: 'Charlie'},
+    ]
+    const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+    table(data, columns, {
+      noStyle: true,
+      sort: {age: 'asc'},
+    })
+    const output = stdout()
+    // Should be sorted by age in ascending order
+    expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('Age   Name'))
+    expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('25    Bob'))
+    expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('30    Alice'))
+    expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('35    Charlie'))
+  })
+
+  it('should use default styling options', function () {
+    const data = [
+      {age: 30, name: 'Alice'},
+    ]
+    const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+    table(data, columns)
+    const output = stdout()
+    // Should have headers-only-with-underline border style
+    expect(output).to.include('─')
+    expect(output).to.include('│')
+    // Should have whiteBright border color
+    expect(output).to.include('\u001B[97m') // ANSI code for whiteBright
+    // Should have purple headers
+    expect(output).to.include('\u001B[38;2;147;112;219m') // ANSI code for rgb(147, 112, 219)
+    // Should contain the data
+    expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('Age   Name'))
+    expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('30    Alice'))
+  })
 })

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -37,20 +37,4 @@ describe('table', function () {
     expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('30    Alice'))
     expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('35    Charlie'))
   })
-
-  it('should use default styling options', function () {
-    const data = [
-      {age: 30, name: 'Alice'},
-    ]
-    const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
-    table(data, columns)
-    const output = stdout()
-    // Should have whiteBright border color
-    expect(output).to.include('\u001B[97m') // ANSI code for whiteBright
-    // Should have purple headers
-    expect(output).to.include('\u001B[38;2;147;112;219m') // ANSI code for rgb(147, 112, 219)
-    // Should contain the data
-    expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('Age   Name'))
-    expect(removeAllWhitespace(output)).to.include(removeAllWhitespace('30    Alice'))
-  })
 })


### PR DESCRIPTION
[W-18575888](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Ek3dFYAR/view)

### Description

This changes the `table` function export to have certain defaults (purple column header text, underline border) while also allowing for those defaults (as well as any oclif defaults) to be overridden by passing in options.

### Testing

1. pull down branch and `npm install`
2. `npm run example table-command`