### PR TITLE
adding export of types and including const for backwards compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,21 @@ import {styledObject} from './ux/styled-object'
 import {table} from './ux/table'
 import {wait} from './ux/wait'
 
+// Export actual types for direct import
+export type {
+  AddOnWithRelatedData,
+  ExtendedAddonAttachment,
+  Link,
+} from './types/pg/data-api'
+
+export type {
+  ConnectionDetails,
+  ConnectionDetailsWithAttachment,
+  TunnelConfig,
+} from './types/pg/tunnel'
+
+// Keep const types for backward compatibility (deprecated)
+/** @deprecated Use direct type imports instead */
 export const types = {
   pg: {
     AddOnWithRelatedData: {} as AddOnWithRelatedData,


### PR DESCRIPTION
This ensures that we can properly type as database connection details.

## Testing
pull: [heroku-cli-util](https://github.com/heroku/heroku-cli-util)
`git checkout mm/const-to-types-export`

pull heroku-pg-extras
`git checkout command-migrations-oclifv2-set1`
update for local testing:
package.json path for heroku-cli-util:
"@heroku/heroku-cli-util": "file:/Users/michael.malave/Desktop/gitclones/heroku-cli-util",

`git checkout command-migrations-oclifv2-set1`
run the following commands
```
npm install
npm run build
npm test
```
then test some commands
```
bin/run pg:bloat --app $APP
bin/run pg:blocking --app $APP
bin/run pg:cache-hit $DATABASE --app $APP
bin/run pg:calls $DATABASE --app $APP
bin/run pg:extensions $DATABASE --app $APP
```