### PR TITLE
refactor: update tunnel-ssh for v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@heroku/http-call": "^5.4.0",
         "@oclif/core": "^2.16.0",
         "debug": "^4.4.0",
-        "tunnel-ssh": "4.1.6"
+        "tunnel-ssh": "5.2.0"
       },
       "devDependencies": {
         "@heroku-cli/schema": "^2.0.0",
@@ -26,7 +26,6 @@
         "@types/node": "^22.15.3",
         "@types/sinon": "^17.0.4",
         "@types/sinon-chai": "^4.0.0",
-        "@types/tunnel-ssh": "4.1.1",
         "chai": "^4.4.1",
         "chai-as-promised": "^7.1.2",
         "eslint": "^8.57.0",
@@ -1151,16 +1150,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/tunnel-ssh": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/tunnel-ssh/-/tunnel-ssh-4.1.1.tgz",
-      "integrity": "sha512-wapC4QO5BBo8viAsHcvKsLBeJM7w9o0uWO9tUqixjD1tiv/iCNyFAKR0DAinyGfb/D76kO3zrq8II3/ehC9RNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
@@ -2100,6 +2089,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -2619,16 +2617,17 @@
       "license": "MIT"
     },
     "node_modules/cpu-features": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
-      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "nan": "^2.14.1"
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/create-require": {
@@ -5577,12 +5576,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -5834,9 +5827,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
       "license": "MIT",
       "optional": true
     },
@@ -7565,20 +7558,20 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ssh2": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
-      "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "asn1": "^0.2.4",
+        "asn1": "^0.2.6",
         "bcrypt-pbkdf": "^1.0.2"
       },
       "engines": {
         "node": ">=10.16.0"
       },
       "optionalDependencies": {
-        "cpu-features": "0.0.2",
-        "nan": "^2.15.0"
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
       }
     },
     "node_modules/stable-hash": {
@@ -7983,30 +7976,13 @@
       }
     },
     "node_modules/tunnel-ssh": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/tunnel-ssh/-/tunnel-ssh-4.1.6.tgz",
-      "integrity": "sha512-y7+x+T3F3rkx2Zov5Tk9DGfeEBVAdWU3A/91E0Dk5rrZ/VFIlpV2uhhRuaISJUdyG0N+Lcp1fXZMXz+ovPt5vA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tunnel-ssh/-/tunnel-ssh-5.2.0.tgz",
+      "integrity": "sha512-IGiyhE2RSt3NVvZ7aKH3ykziAxKNPe/z97Rab/lrIXslif/cq7J/m6EXfERlDITiFyGGYMqqi5SSrt/mk1VbEg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "lodash.defaults": "^4.1.0",
-        "ssh2": "1.4.0"
+        "ssh2": "^1.15.0"
       }
-    },
-    "node_modules/tunnel-ssh/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/tunnel-ssh/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@heroku/http-call": "^5.4.0",
     "@oclif/core": "^2.16.0",
     "debug": "^4.4.0",
-    "tunnel-ssh": "4.1.6"
+    "tunnel-ssh": "5.2.0"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/node": "^22.15.3",
     "@types/sinon": "^17.0.4",
     "@types/sinon-chai": "^4.0.0",
-    "@types/tunnel-ssh": "4.1.1",
     "chai": "^4.4.1",
     "chai-as-promised": "^7.1.2",
     "eslint": "^8.57.0",

--- a/src/types/pg/tunnel.ts
+++ b/src/types/pg/tunnel.ts
@@ -1,5 +1,4 @@
 import {Server} from 'node:net'
-import * as createTunnel from 'tunnel-ssh'
 
 import type {ExtendedAddonAttachment} from './data-api'
 
@@ -18,7 +17,15 @@ export type ConnectionDetailsWithAttachment = {
   attachment: ExtendedAddonAttachment
 } & ConnectionDetails
 
-export type TunnelConfig = createTunnel.Config
+export interface TunnelConfig {
+  dstHost: string
+  dstPort: number
+  host?: string
+  localHost: string
+  localPort: number
+  privateKey?: string
+  username: string
+}
 
 export interface BastionConfigResponse {
   host: string

--- a/src/utils/pg/bastion.ts
+++ b/src/utils/pg/bastion.ts
@@ -257,6 +257,9 @@ class Timeout {
  * Adapter for tunnel-ssh v5 API. Translates our TunnelConfig into the v5
  * createTunnel(tunnelOptions, serverOptions, sshOptions, forwardOptions) call
  * and returns the created local Server.
+ *
+ * @param config - The tunnel configuration to translate for v5 API
+ * @returns Promise that resolves to the created local TCP Server
  */
 async function createSSHTunnelAdapter(config: TunnelConfig): Promise<Server> {
   const tunnelOptions = {
@@ -271,22 +274,22 @@ async function createSSHTunnelAdapter(config: TunnelConfig): Promise<Server> {
 
   const sshOptions = {
     host: config.host,
-    username: config.username,
     privateKey: config.privateKey,
+    username: config.username,
   }
 
   const forwardOptions = {
-    srcAddr: config.localHost,
-    srcPort: config.localPort,
     dstAddr: config.dstHost,
     dstPort: config.dstPort,
+    srcAddr: config.localHost,
+    srcPort: config.localPort,
   }
 
   const [server] = await tunnelSsh.createTunnel(
     tunnelOptions,
     serverOptions,
     sshOptions,
-    forwardOptions
+    forwardOptions,
   )
   return server
 }

--- a/src/utils/pg/bastion.ts
+++ b/src/utils/pg/bastion.ts
@@ -285,8 +285,8 @@ async function createSSHTunnelAdapter(config: TunnelConfig): Promise<Server> {
   const [server] = await tunnelSsh.createTunnel(
     tunnelOptions,
     serverOptions,
-    sshOptions as unknown as Parameters<typeof tunnelSsh.createTunnel>[2],
-    forwardOptions as unknown as Parameters<typeof tunnelSsh.createTunnel>[3],
+    sshOptions,
+    forwardOptions
   )
   return server
 }

--- a/test/unit/utils/pg/bastion.test.ts
+++ b/test/unit/utils/pg/bastion.test.ts
@@ -6,9 +6,7 @@ import * as chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import nock from 'nock'
 import {Server} from 'node:net'
-import {promisify} from 'node:util'
 import sinon from 'sinon'
-import * as createTunnel from 'tunnel-ssh'
 
 import {
   bastionKeyPlan,
@@ -554,14 +552,11 @@ describe('bastion', function () {
   })
 
   describe('sshTunnel', function () {
-    let createTunnelStub: sinon.SinonStub<
-      Parameters<typeof createTunnel.default>,
-      Promise<ReturnType<typeof createTunnel.default>>
-    >
+    let createTunnelStub: sinon.SinonStub<[unknown], Promise<Server>>
     let clock: sinon.SinonFakeTimers
 
     beforeEach(function () {
-      // Stub the createTunnel.default function
+      // Stub the tunnel creation function
       createTunnelStub = sinon.stub()
       clock = sinon.useFakeTimers()
     })
@@ -576,7 +571,7 @@ describe('bastion', function () {
         const connectionDetails = defaultConnectionDetails
         const {dbTunnelConfig} = defaultPsqlConfigs
 
-        const result = await sshTunnel(connectionDetails, dbTunnelConfig, 1000, promisify(createTunnelStub))
+        const result = await sshTunnel(connectionDetails, dbTunnelConfig, 1000, createTunnelStub)
 
         expect(result).to.be.undefined
         expect(createTunnelStub).to.not.have.been.called


### PR DESCRIPTION
# Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002M33k2YAB/view)

This PR upgrades `tunnel-ssh` from `v4.1.6` to `v5.2.0` as part of a plugin installation bug fix. The v5 release had breaking changes with the removal of the v4 default export and its `Config` type while using a promise-based createTunnel() API with built-in types. The `createTunnel` function now requires `tunnelOptions`, `serverOptions`, `sshOptions`, `forwardOptions` parameters. The arguments supplied in the new `createSSHTunnelAdapter()` correspond with the returned object from `tunnelConfig()`.

# Testing
- Passing CI