### PR TITLE
Release v9.1.2 (W-19689442)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heroku/heroku-cli-util",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heroku/heroku-cli-util",
-      "version": "9.1.1",
+      "version": "9.1.2",
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/color": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/heroku-cli-util",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Set of helpful CLI utilities",
   "author": "Heroku",
   "license": "ISC",


### PR DESCRIPTION
## Description

We just did a release for v9.x to be integrated to Core CLI 10.x, but this package runs on a different version of `@heroku-cli/command` that causes type incompatibilities with the one shipped with CLI 10.x.

Here we just realign versions of shared libs with the ones in use by Core CLI to avoid those problems.

## References
GUS Work Item: [W-19689442](https://gus.lightning.force.com/a07EE00002M33k2YAB)

## Testing

N/A
