### PR TITLE
chore: hide dev dependency bumps from release-please changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       day: "sunday"
       timezone: "America/Los_Angeles"
     commit-message:
-      prefix: "deps"
+      prefix: "deps(dev)"
   - package-ecosystem: "npm"
     directory: "/"
     open-pull-requests-limit: 5
@@ -20,6 +20,7 @@ updates:
       timezone: "America/Los_Angeles"
     commit-message:
       prefix: "deps"
+      prefix-development: "deps(dev)"
     groups:
       dev-patch-minor-dependencies:
         dependency-type: "development"

--- a/.github/release-configs/release-please-config.beta.json
+++ b/.github/release-configs/release-please-config.beta.json
@@ -8,7 +8,27 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "prerelease": true,
-      "prerelease-type": "beta"
+      "prerelease-type": "beta",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        {
+          "type": "deps",
+          "scope": "dev",
+          "section": "Dependencies",
+          "hidden": true
+        },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",

--- a/.github/release-configs/release-please-config.json
+++ b/.github/release-configs/release-please-config.json
@@ -6,7 +6,27 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": ["README.md"],
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        {
+          "type": "deps",
+          "scope": "dev",
+          "section": "Dependencies",
+          "hidden": true
+        },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",


### PR DESCRIPTION
## Summary
- Add explicit `changelog-sections` to both release-please configs (stable + beta) so we can control which commit types appear in the generated CHANGELOG.
- Hide `deps(dev)` (development dependency bumps), `docs`, `style`, `chore`, `test`, `build`, and `ci` entries from the changelog while keeping production `deps` visible.
- Update `.github/dependabot.yml` so dev-only ecosystems use the `deps(dev)` commit prefix, enabling the hidden-section rule above.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: Configuration-only change to release-please and dependabot. Effects will be visible on the next release-please PR and the next dependabot run.

**Steps**:
1. Passing CI suffices.
2. Verify the next release-please PR groups commits using the new sections (production `deps` shown under "Dependencies"; `deps(dev)`, `chore`, `test`, etc. omitted).
3. Verify dependabot opens future dev-only dependency PRs with the `deps(dev):` commit prefix.

## Screenshots (if applicable)

## Related Issues
GitHub issue: #[GitHub issue number]
GUS work item: [WI number](WI link)