### PR TITLE
feat: restore --columns, --csv, --extended, --filter, and --sort

### DIFF
--- a/examples/table-command.ts
+++ b/examples/table-command.ts
@@ -1,26 +1,38 @@
-import {Command} from '@oclif/core'
+import {Command, Flags} from '@oclif/core'
 
 import {table} from '../src/ux/table.js'
 
 export default class TableCommand extends Command {
-  static description = 'Example command demonstrating table usage'
+  static description = 'Example command demonstrating table usage with flags'
+  static flags = {
+    columns: Flags.string({description: 'Only show specified columns (comma-separated)'}),
+    csv: Flags.boolean({description: 'Output in CSV format'}),
+    extended: Flags.boolean({description: 'Show extended columns'}),
+    filter: Flags.string({description: 'Filter rows by property=value'}),
+    sort: Flags.string({description: 'Sort by property (comma-separated for multi-column)'}),
+  }
 
   async run() {
+    const {flags} = await this.parse(TableCommand)
+
     // Sample data to display in the table
     const data = [
       {
+        email: 'john@example.com',
         id: 1,
         name: 'John Doe',
         role: 'Developer',
         status: 'Active',
       },
       {
+        email: 'jane@example.com',
         id: 2,
         name: 'Jane Smith',
         role: 'Designer',
         status: 'On Leave',
       },
       {
+        email: 'bob@example.com',
         id: 3,
         name: 'Bob Johnson',
         role: 'Manager',
@@ -30,6 +42,11 @@ export default class TableCommand extends Command {
 
     // Define the columns configuration
     const columns = {
+      email: {
+        extended: true,  // Hidden by default, shown with --extended
+        header: 'Email',
+        minWidth: 15,
+      },
       id: {
         header: 'ID',
         minWidth: 2,
@@ -48,8 +65,9 @@ export default class TableCommand extends Command {
       },
     }
 
-    // Display the table
+    // Display the table with flags
     table(data, columns, {
+      ...flags,  // Pass all flags to table function
       printLine: this.log.bind(this),
     })
   }

--- a/examples/table-command.ts
+++ b/examples/table-command.ts
@@ -42,11 +42,6 @@ export default class TableCommand extends Command {
 
     // Define the columns configuration
     const columns = {
-      email: {
-        extended: true,  // Hidden by default, shown with --extended
-        header: 'Email',
-        minWidth: 15,
-      },
       id: {
         header: 'ID',
         minWidth: 2,
@@ -62,6 +57,12 @@ export default class TableCommand extends Command {
       status: {
         header: 'Status',
         minWidth: 8,
+      },
+      // eslint-disable-next-line perfectionist/sort-objects
+      email: {
+        extended: true,  // Hidden by default, shown with --extended
+        header: 'Email',
+        minWidth: 15,
       },
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "ansis": "^4.1.0",
         "debug": "^4.4.0",
         "inquirer": "^12.6.1",
+        "natural-orderby": "^5.0.0",
         "open": "^11",
         "printf": "^0.6.1",
         "tsheredoc": "^1.0.1",
@@ -4949,16 +4950,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-config-oclif/node_modules/natural-orderby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz",
-      "integrity": "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/eslint-config-oclif/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -7934,6 +7925,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/natural-orderby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz",
+      "integrity": "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nock": {
       "version": "14.0.15",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ansis": "^4.1.0",
     "debug": "^4.4.0",
     "inquirer": "^12.6.1",
+    "natural-orderby": "^5.0.0",
     "open": "^11",
     "printf": "^0.6.1",
     "tsheredoc": "^1.0.1",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,7 @@ export {
   isLegacyEssentialDatabase,
   isPostgresAddon,
 } from './addons/helpers.js'
+export {default as parseKeyValue} from './parse-key-value.js'
 export {getPsqlConfigs, sshTunnel} from './pg/bastion.js'
 export {getConfigVarNameFromAttachment} from './pg/config-vars.js'
 export {default as DatabaseResolver} from './pg/databases.js'

--- a/src/utils/parse-key-value.ts
+++ b/src/utils/parse-key-value.ts
@@ -1,0 +1,6 @@
+export default function parseKeyValue(input: string) {
+  let [key, value] = input.split(/=(.*)/)
+  key = key.trim()
+  value = value ? value.trim() : ''
+  return {key, value}
+}

--- a/src/ux/table.ts
+++ b/src/ux/table.ts
@@ -49,7 +49,7 @@ function selectColumns<T extends Record<string, unknown>>(
   flags: {columns?: string; extended?: boolean},
 ): Columns<T> {
   if (flags.columns) {
-    const columnIds = flags.columns.split(',');
+    const columnIds = flags.columns.split(',').filter(id => id.trim());
     const uniqueColumnIds = [...new Set(columnIds)];
 
     const selectedColumns: Columns<T> = {};
@@ -112,6 +112,7 @@ function getFilterPredicate<T extends Record<string, unknown>>(
 function getSortIds<T extends Record<string, unknown>>(columns: Columns<T>, sort: string): string[] {
   const sortIds = sort
     .split(',')
+    .filter(id => id.trim())
     .map(id => {
       const column = getColumnById(id, columns);
       if (!column) {
@@ -177,11 +178,7 @@ export function table<T extends Record<string, unknown>>(
 
   if (options?.sort) {
     const sortIds = getSortIds(selectedColumns, options.sort);
-    processedData = orderBy(
-      processedData,
-      sortIds.map(id => row => row[id]),
-      ['asc'],
-    );
+    processedData = orderBy(processedData, sortIds, ['asc']);
   }
 
   if (options?.csv) {

--- a/src/ux/table.ts
+++ b/src/ux/table.ts
@@ -1,4 +1,8 @@
+import {ux} from '@oclif/core/ux'
 import {printTable, TableOptions} from '@oclif/table'
+import {orderBy} from 'natural-orderby'
+
+import parseKeyValue from '../utils/parse-key-value.js'
 
 type Column<T extends Record<string, unknown>> = {
   extended: boolean;
@@ -9,34 +13,203 @@ type Column<T extends Record<string, unknown>> = {
 
 type Columns<T extends Record<string, unknown>> = {[key: string]: Partial<Column<T>>};
 
+type TableFlags = {
+  columns?: string;     // Comma-separated column identifiers (headers or keys)
+  csv?: boolean;        // Enable CSV output
+  extended?: boolean;   // Show extended columns
+  filter?: string;      // Property=value filter (simple includes matching)
+  sort?: string;        // Comma-separated property names (ascending only)
+};
+
+/**
+ * Finds a column by id (header name or property key), case-insensitively.
+ * Returns undefined if no match found.
+ */
+function getColumnById<T extends Record<string, unknown>>(
+  id: string,
+  columns: Columns<T>,
+): [string, Partial<Column<T>>] | undefined {
+  const lowerCaseId = id.toLowerCase();
+
+  for (const [key, col] of Object.entries(columns)) {
+    if (col.header?.toLowerCase() === lowerCaseId || key.toLowerCase() === lowerCaseId) {
+      return [key, col];
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Selects columns based on --columns or --extended flags.
+ * --columns takes precedence over --extended.
+ */
+function selectColumns<T extends Record<string, unknown>>(
+  columns: Columns<T>,
+  flags: {columns?: string; extended?: boolean},
+): Columns<T> {
+  if (flags.columns) {
+    const columnIds = flags.columns.split(',');
+    const uniqueColumnIds = [...new Set(columnIds)];
+
+    const selectedColumns: Columns<T> = {};
+
+    for (const id of uniqueColumnIds) {
+      const column = getColumnById(id, columns);
+      if (!column) {
+        throw new Error('Columns flag has an invalid value.');
+      }
+
+      const [key, col] = column;
+      selectedColumns[key] = col;
+    }
+
+    return selectedColumns;
+  }
+
+  if (!flags.extended) {
+    const baseColumns: Columns<T> = {};
+    for (const [key, col] of Object.entries(columns)) {
+      if (!col.extended) {
+        baseColumns[key] = col;
+      }
+    }
+
+    return baseColumns;
+  }
+
+  return columns;
+}
+
+/**
+ * Builds a filter predicate function for substring matching.
+ */
+function getFilterPredicate<T extends Record<string, unknown>>(
+  columns: Columns<T>,
+  filter: string,
+): (row: Record<string, unknown>) => boolean {
+  const {key: columnId, value: searchValue} = parseKeyValue(filter);
+
+  if (!searchValue) {
+    throw new Error('Filter flag has an invalid value.');
+  }
+
+  const column = getColumnById(columnId, columns);
+  if (!column) {
+    throw new Error('Filter flag has an invalid value.');
+  }
+
+  const [key] = column;
+  return (row: Record<string, unknown>) => {
+    const cellValue = String(row[key] ?? '');
+    return cellValue.includes(searchValue);
+  };
+}
+
+/**
+ * Gets the identifiers for the sort properties.
+ */
+function getSortIds<T extends Record<string, unknown>>(columns: Columns<T>, sort: string): string[] {
+  const sortIds = sort
+    .split(',')
+    .map(id => {
+      const column = getColumnById(id, columns);
+      if (!column) {
+        throw new Error('Sort flag has an invalid value.');
+      }
+
+      const [key] = column;
+      return key;
+    });
+
+  if (sortIds.length === 0) {
+    throw new Error('Sort flag has an invalid value.');
+  }
+
+  return sortIds;
+}
+
+function escapeCSV(value: string): string {
+  const needsEscaping = /["\n\r,]/.test(value);
+  return needsEscaping ? `"${value.replaceAll('"', '""')}"` : value;
+}
+
+function outputCSV<T extends Record<string, unknown>>(
+  data: T[],
+  columns: Columns<T>,
+  printLine: (s: string) => void,
+): void {
+  const columnEntries = Object.entries(columns);
+  const columnHeaders = columnEntries.map(([key, col]) => col.header || key);
+
+  printLine(columnHeaders.join(','));
+
+  for (const row of data) {
+    const values = columnEntries.map(([key]) => {
+      const value = row[key];
+      return escapeCSV(String(value ?? ''));
+    });
+
+    printLine(values.join(','));
+  }
+}
+
 export function table<T extends Record<string, unknown>>(
   data: T[],
   columns: Columns<T>,
-  options?: Omit<TableOptions<T>, 'columns' | 'data'> & {printLine?(s: unknown): void},
+  options?: Omit<TableOptions<T>, 'columns' | 'data' | 'filter' | 'sort'> & TableFlags & {printLine?(s: unknown): void;},
 ) {
-  const cols = Object.entries(columns).map(([key, opts]) => {
-    if (opts.header) return {key, name: opts.header}
-    return key
-  })
-  const d = data.map(row =>
-    Object.fromEntries(Object.entries(columns).map(([key, {get}]) => [key, get ? get(row) : row[key]]))) as Array<Record<string, unknown>>
+  const selectedColumns = selectColumns(columns, {
+    columns: options?.columns,
+    extended: options?.extended,
+  });
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {printLine, ...tableOptions} = options || {}
+  let processedData = data.map(row =>
+    Object.fromEntries(Object.entries(selectedColumns).map(([key, {get}]) => [
+      key,
+      get ? get(row) : row[key],
+    ]))) as Array<Record<string, unknown>>;
 
-  printTable({
-    ...(tableOptions?.noStyle
-      ? {}
-      : {
-        borderColor: 'whiteBright',
-        borderStyle: 'headers-only-with-underline',
-        headerOptions: {
-          bold: true,
-          color: 'white', // or 'reset' to use default terminal color
-        },
-      }),
-    ...tableOptions,
-    columns: cols,
-    data: d as T[],
-  })
+  if (options?.filter) {
+    const filterPredicate = getFilterPredicate(selectedColumns, options.filter);
+    processedData = processedData.filter(row => filterPredicate(row));
+  }
+
+  if (options?.sort) {
+    const sortIds = getSortIds(selectedColumns, options.sort);
+    processedData = orderBy(
+      processedData,
+      sortIds.map(id => row => row[id]),
+      ['asc'],
+    );
+  }
+
+  if (options?.csv) {
+    const printFn = options?.printLine || ux.stdout;
+    outputCSV(processedData, selectedColumns, printFn);
+  } else {
+    const cols = Object.entries(selectedColumns).map(([key, opts]) => {
+      if (opts.header) return {key, name: opts.header};
+      return key;
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {columns, csv, extended, filter, printLine, sort, ...tableOptions} = options || {};
+
+    printTable({
+      ...(tableOptions?.noStyle
+        ? {}
+        : {
+          borderColor: 'whiteBright',
+          borderStyle: 'headers-only-with-underline',
+          headerOptions: {
+            bold: true,
+            color: 'white', // or 'reset' to use default terminal color
+          },
+        }),
+      ...tableOptions,
+      columns: cols,
+      data: processedData as T[],
+    });
+  }
 }

--- a/test/unit/utils/parse-key-value.test.ts
+++ b/test/unit/utils/parse-key-value.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'vitest'
+
+import parseKeyValue from '../../../src/utils/parse-key-value.js'
+
+describe('parseKeyValue', () => {
+  it('should parse basic key=value input', () => {
+    const result = parseKeyValue('name=John')
+    expect(result).toEqual({key: 'name', value: 'John'})
+  })
+
+  it('should handle empty value', () => {
+    const result = parseKeyValue('name=')
+    expect(result).toEqual({key: 'name', value: ''})
+  })
+
+  it('should handle missing equals sign', () => {
+    const result = parseKeyValue('name')
+    expect(result).toEqual({key: 'name', value: ''})
+  })
+
+  it('should split only on first equals sign', () => {
+    const result = parseKeyValue('url=https://example.com?a=1&b=2')
+    expect(result).toEqual({key: 'url', value: 'https://example.com?a=1&b=2'})
+  })
+
+  it('should handle special characters in value', () => {
+    const result = parseKeyValue('description=Hello,"World"!')
+    expect(result).toEqual({key: 'description', value: 'Hello,"World"!'})
+  })
+
+  it('should handle empty string input', () => {
+    const result = parseKeyValue('')
+    expect(result).toEqual({key: '', value: ''})
+  })
+})

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -191,16 +191,16 @@ describe('table', function () {
 
     it('should escape CSV when values contain carriage returns', async function () {
       const data = [
-        {status: 'sent', text: 'Line1\r\nLine2'},
-        {status: 'read', text: 'Normal'},
+        {message: 'Line 1\r\nLine 2', status: 'sent'},
+        {message: 'Normal', status: 'read'},
       ]
-      const columns = {status: {header: 'Status'}, text: {header: 'Text'}}
+      const columns = {message: {header: 'Message'}, status: {header: 'Status'}}
       const {stdout} = await captureOutput(() =>
         table(data, columns, {
           csv: true,
         }))
 
-      expect(stdout.trim()).toBe('Text,Status\n"Line1\r\nLine2",sent\nNormal,read')
+      expect(stdout.trim()).toBe('Message,Status\n"Line 1\r\nLine 2",sent\nNormal,read')
     })
   })
 

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -14,9 +14,11 @@ describe('table', function () {
     ]
     const columns = {baz: {header: 'Baz'}, foo: {header: 'Foo'}}
     const {stdout} = await captureOutput(() => table(data, columns, {noStyle: true}))
-    expect(removeAllWhitespace(stdout)).toContain(removeAllWhitespace('Baz   Foo'))
-    expect(removeAllWhitespace(stdout)).toContain(removeAllWhitespace('42    bar'))
-    expect(removeAllWhitespace(stdout)).toContain(removeAllWhitespace('7     qux'))
+
+    const strippedOutput = removeAllWhitespace(stdout)
+    expect(strippedOutput).toContain(removeAllWhitespace('Baz   Foo'))
+    expect(strippedOutput).toContain(removeAllWhitespace('42    bar'))
+    expect(strippedOutput).toContain(removeAllWhitespace('7     qux'))
   })
 
   it('should respect sort options', async function () {
@@ -29,12 +31,429 @@ describe('table', function () {
     const {stdout} = await captureOutput(() =>
       table(data, columns, {
         noStyle: true,
-        sort: {age: 'asc'},
+        sort: 'age',
       }))
+
+    const strippedOutput = removeAllWhitespace(stdout)
     // Should be sorted by age in ascending order
-    expect(removeAllWhitespace(stdout)).toContain(removeAllWhitespace('Age   Name'))
-    expect(removeAllWhitespace(stdout)).toContain(removeAllWhitespace('25    Bob'))
-    expect(removeAllWhitespace(stdout)).toContain(removeAllWhitespace('30    Alice'))
-    expect(removeAllWhitespace(stdout)).toContain(removeAllWhitespace('35    Charlie'))
+    expect(strippedOutput).toContain(removeAllWhitespace('Age   Name'))
+    expect(strippedOutput).toContain(removeAllWhitespace('25    Bob'))
+    expect(strippedOutput).toContain(removeAllWhitespace('30    Alice'))
+    expect(strippedOutput).toContain(removeAllWhitespace('35    Charlie'))
+  })
+
+  describe('--columns flag', function () {
+    it('should match by header name', async function () {
+      const data = [
+        {age: 30, city: 'NYC', name: 'Alice'},
+        {age: 25, city: 'LA', name: 'Bob'},
+      ]
+      const columns = {age: {header: 'Age'}, city: {header: 'City'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          columns: 'Name,City',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain(removeAllWhitespace('Name   City'))
+      expect(strippedOutput).toContain(removeAllWhitespace('Alice  NYC'))
+      expect(strippedOutput).toContain(removeAllWhitespace('Bob    LA'))
+      expect(strippedOutput).not.toContain('Age')
+    })
+
+    it('should match by property key', async function () {
+      const data = [
+        {age: 30, name: 'Alice'},
+        {age: 25, name: 'Bob'},
+      ]
+      const columns = {age: {header: 'Age'}, name: {}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          columns: 'name',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('name')
+      expect(strippedOutput).toContain('Alice')
+      expect(strippedOutput).toContain('Bob')
+      expect(strippedOutput).not.toContain('Age')
+    })
+
+    it('should preserve order of specified columns', async function () {
+      const data = [
+        {age: 30, city: 'NYC', name: 'Alice'},
+      ]
+      const columns = {age: {header: 'Age'}, city: {header: 'City'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          columns: 'City,Name,Age',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      const cityIndex = strippedOutput.indexOf('City')
+      const nameIndex = strippedOutput.indexOf('Name')
+      const ageIndex = strippedOutput.indexOf('Age')
+
+      expect(cityIndex).toBeLessThan(nameIndex)
+      expect(nameIndex).toBeLessThan(ageIndex)
+    })
+
+    it('should deduplicate repeated columns', async function () {
+      const data = [
+        {age: 30, name: 'Alice'},
+      ]
+      const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          columns: 'Name,Name,Age',
+        }))
+
+      const nameOccurrences = (stdout.match(/Name/g) || []).length
+
+      expect(nameOccurrences).toBe(1)
+    })
+
+    it('should error for unknown columns', async function () {
+      const data = [
+        {age: 30, name: 'Alice'},
+      ]
+      const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+
+      expect(() =>
+        table(data, columns, {
+          columns: 'Name,Invalid',
+        })).toThrow(/Columns flag has an invalid value/)
+    })
+  })
+
+  describe('--csv flag', function () {
+    it('should output CSV with headers', async function () {
+      const data = [
+        {age: 30, name: 'Alice'},
+        {age: 25, name: 'Bob'},
+      ]
+      const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          csv: true,
+        }))
+
+      expect(stdout.trim()).toBe('Age,Name\n30,Alice\n25,Bob')
+    })
+
+    it('should escape CSV when values contain commas', async function () {
+      const data = [
+        {name: 'Alice, Jr.', role: 'Developer'},
+        {name: 'Bob', role: 'Manager, Lead'},
+      ]
+      const columns = {name: {header: 'Name'}, role: {header: 'Role'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          csv: true,
+        }))
+
+      const lines = stdout.trim().split('\n')
+      expect(lines[0]).toBe('Name,Role')
+      expect(lines[1]).toBe('"Alice, Jr.",Developer')
+      expect(lines[2]).toBe('Bob,"Manager, Lead"')
+    })
+
+    it('should escape CSV when values contain quotes', async function () {
+      const data = [
+        {message: 'She said "hello"', status: 'sent'},
+        {message: 'Normal text', status: 'read'},
+      ]
+      const columns = {message: {header: 'Message'}, status: {header: 'Status'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          csv: true,
+        }))
+
+      const lines = stdout.trim().split('\n')
+      expect(lines[0]).toBe('Message,Status')
+      expect(lines[1]).toBe('"She said ""hello""",sent')
+      expect(lines[2]).toBe('Normal text,read')
+    })
+
+    it('should escape CSV when values contain newlines', async function () {
+      const data = [
+        {message: 'Line 1\nLine 2', status: 'sent'},
+        {message: 'Normal', status: 'read'},
+      ]
+      const columns = {message: {header: 'Message'}, status: {header: 'Status'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          csv: true,
+        }))
+
+      expect(stdout.trim()).toBe('Message,Status\n"Line 1\nLine 2",sent\nNormal,read')
+    })
+  })
+
+  describe('--filter flag', function () {
+    it('should filter by substring match', async function () {
+      const data = [
+        {age: 30, name: 'Alice'},
+        {age: 25, name: 'Bob'},
+        {age: 35, name: 'Charlie'},
+      ]
+      const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          filter: 'name=li',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('Alice')
+      expect(strippedOutput).toContain('Charlie')
+      expect(strippedOutput).not.toContain('Bob')
+    })
+
+    it('should filter by exact match', async function () {
+      const data = [
+        {age: 30, name: 'Alice'},
+        {age: 25, name: 'Bob'},
+        {age: 35, name: 'Charlie'},
+      ]
+      const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          filter: 'name=Alice',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('Alice')
+      expect(strippedOutput).not.toContain('Charlie')
+      expect(strippedOutput).not.toContain('Bob')
+    })
+
+    it('should error for invalid format missing equals', async function () {
+      const data = [
+        {name: 'Alice'},
+      ]
+      const columns = {name: {header: 'Name'}}
+
+      expect(() =>
+        table(data, columns, {
+          filter: 'nameAlice',
+        })).toThrow(/Filter flag has an invalid value/)
+    })
+
+    it('should error for invalid format missing value', async function () {
+      const data = [
+        {name: 'Alice'},
+      ]
+      const columns = {name: {header: 'Name'}}
+
+      expect(() =>
+        table(data, columns, {
+          filter: 'name=',
+        })).toThrow(/Filter flag has an invalid value/)
+    })
+
+    it('should error for unknown column', async function () {
+      const data = [
+        {name: 'Alice'},
+      ]
+      const columns = {name: {header: 'Name'}}
+
+      expect(() =>
+        table(data, columns, {
+          filter: 'invalid=test',
+        })).toThrow(/Filter flag has an invalid value/)
+    })
+  })
+
+  describe('--sort flag', function () {
+    it('should sort by single column ascending', async function () {
+      const data = [
+        {age: 30, name: 'Alice'},
+        {age: 25, name: 'Bob'},
+        {age: 35, name: 'Charlie'},
+      ]
+      const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          sort: 'age',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      const bobIndex = strippedOutput.indexOf('Bob')
+      const aliceIndex = strippedOutput.indexOf('Alice')
+      const charlieIndex = strippedOutput.indexOf('Charlie')
+
+      expect(bobIndex).toBeLessThan(aliceIndex)
+      expect(aliceIndex).toBeLessThan(charlieIndex)
+    })
+
+    it('should sort by multi-column ascending', async function () {
+      const data = [
+        {age: 30, city: 'NYC', name: 'Alice'},
+        {age: 25, city: 'NYC', name: 'Diana'},
+        {age: 25, city: 'LA', name: 'Bob'},
+        {age: 30, city: 'LA', name: 'Charlie'},
+      ]
+      const columns = {age: {header: 'Age'}, city: {header: 'City'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          sort: 'age,city',
+        }))
+
+      const stripped = removeAllWhitespace(stdout)
+      const bobIndex = stripped.indexOf('Bob')     // age 25, city LA
+      const dianaIndex = stripped.indexOf('Diana')  // age 25, city NYC
+      const charlieIndex = stripped.indexOf('Charlie') // age 30, city LA
+      const aliceIndex = stripped.indexOf('Alice')  // age 30, city NYC
+
+      // Within age 25: LA before NYC
+      expect(bobIndex).toBeLessThan(dianaIndex)
+      // Within age 30: LA before NYC
+      expect(charlieIndex).toBeLessThan(aliceIndex)
+      // Age 25 before age 30
+      expect(bobIndex).toBeLessThan(charlieIndex)
+    })
+
+    it('should error for unknown column', async function () {
+      const data = [
+        {name: 'Alice'},
+      ]
+      const columns = {name: {header: 'Name'}}
+
+      expect(() =>
+        table(data, columns, {
+          sort: 'invalid',
+        })).toThrow(/Sort flag has an invalid value/)
+    })
+  })
+
+  describe('--extended flag', function () {
+    it('should hide extended columns by default', async function () {
+      const data = [
+        {age: 30, name: 'Alice', secret: 'password123'},
+      ]
+      const columns = {
+        age: {header: 'Age'},
+        name: {header: 'Name'},
+        secret: {extended: true, header: 'Secret'},
+      }
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {}))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('Name')
+      expect(strippedOutput).toContain('Age')
+      expect(strippedOutput).not.toContain('Secret')
+      expect(strippedOutput).not.toContain('password123')
+    })
+
+    it('should show extended columns when flag is set', async function () {
+      const data = [
+        {age: 30, name: 'Alice', secret: 'password123'},
+      ]
+      const columns = {
+        age: {header: 'Age'},
+        name: {header: 'Name'},
+        secret: {extended: true, header: 'Secret'},
+      }
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          extended: true,
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('Name')
+      expect(strippedOutput).toContain('Age')
+      expect(strippedOutput).toContain('Secret')
+      expect(strippedOutput).toContain('password123')
+    })
+
+    it('should let --columns override --extended', async function () {
+      const data = [
+        {age: 30, name: 'Alice', secret: 'password123'},
+      ]
+      const columns = {
+        age: {header: 'Age'},
+        name: {header: 'Name'},
+        secret: {extended: true, header: 'Secret'},
+      }
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          columns: 'Name',
+          extended: true,
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('Name')
+      expect(strippedOutput).not.toContain('Age')
+      expect(strippedOutput).not.toContain('Secret')
+    })
+  })
+
+  describe('combined flags', function () {
+    it('should support filter + sort + columns', async function () {
+      const data = [
+        {age: 35, city: 'NYC', name: 'Charlie'},
+        {age: 30, city: 'NYC', name: 'Alice'},
+        {age: 25, city: 'LA', name: 'Bob'},
+        {age: 28, city: 'LA', name: 'Diana'},
+      ]
+      const columns = {age: {header: 'Age'}, city: {header: 'City'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          columns: 'Name,Age',
+          filter: 'name=li',
+          sort: 'age',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+
+      // Columns flag
+      expect(strippedOutput).toContain(removeAllWhitespace('Name   Age'))
+      expect(strippedOutput).not.toContain('City')
+
+      // Filter flag
+      expect(strippedOutput).toContain('Alice')
+      expect(strippedOutput).toContain('Charlie')
+      expect(strippedOutput).not.toContain('Bob')
+      expect(strippedOutput).not.toContain('Diana')
+
+      // Sort flag
+      const aliceIndex = strippedOutput.indexOf('Alice')
+      const charlieIndex = strippedOutput.indexOf('Charlie')
+      expect(aliceIndex).toBeLessThan(charlieIndex)
+    })
+
+    it('should support filter + sort + columns + csv', async function () {
+      const data = [
+        {
+          age: 35, city: 'NYC', name: 'Charlie', role: 'Developer',
+        },
+        {
+          age: 30, city: 'NYC', name: 'Alice', role: 'Developer',
+        },
+        {
+          age: 25, city: 'LA', name: 'Bob', role: 'Manager',
+        },
+        {
+          age: 28, city: 'LA', name: 'Diana', role: 'Designer',
+        },
+      ]
+      const columns = {
+        age: {header: 'Age'}, city: {header: 'City'}, name: {header: 'Name'}, role: {header: 'Role'},
+      }
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          columns: 'Age,City,Name',
+          csv: true,
+          filter: 'city=NYC',
+          sort: 'age',
+        }))
+
+      const lines = stdout.trim().split('\n')
+      expect(lines[0]).toBe('Age,City,Name')
+      expect(lines[1]).toBe('30,NYC,Alice')
+      expect(lines[2]).toBe('35,NYC,Charlie')
+      expect(lines.length).toBe(3)
+    })
   })
 })

--- a/test/unit/ux/table.test.ts
+++ b/test/unit/ux/table.test.ts
@@ -188,6 +188,20 @@ describe('table', function () {
 
       expect(stdout.trim()).toBe('Message,Status\n"Line 1\nLine 2",sent\nNormal,read')
     })
+
+    it('should escape CSV when values contain carriage returns', async function () {
+      const data = [
+        {status: 'sent', text: 'Line1\r\nLine2'},
+        {status: 'read', text: 'Normal'},
+      ]
+      const columns = {status: {header: 'Status'}, text: {header: 'Text'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          csv: true,
+        }))
+
+      expect(stdout.trim()).toBe('Text,Status\n"Line1\r\nLine2",sent\nNormal,read')
+    })
   })
 
   describe('--filter flag', function () {
@@ -454,6 +468,54 @@ describe('table', function () {
       expect(lines[1]).toBe('30,NYC,Alice')
       expect(lines[2]).toBe('35,NYC,Charlie')
       expect(lines.length).toBe(3)
+    })
+  })
+
+  describe('empty data', function () {
+    it('should handle empty data array', async function () {
+      const data: Array<{age: number; name: string}> = []
+      const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('Name')
+      expect(strippedOutput).toContain('Age')
+    })
+
+    it('should handle empty data array with CSV', async function () {
+      const data: Array<{age: number; name: string}> = []
+      const columns = {age: {header: 'Age'}, name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          csv: true,
+        }))
+
+      expect(stdout.trim()).toBe('Age,Name')
+    })
+
+    it('should handle empty data array with filter', async function () {
+      const data: Array<{name: string}> = []
+      const columns = {name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          filter: 'name=test',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('Name')
+    })
+
+    it('should handle empty data array with sort', async function () {
+      const data: Array<{name: string}> = []
+      const columns = {name: {header: 'Name'}}
+      const {stdout} = await captureOutput(() =>
+        table(data, columns, {
+          sort: 'name',
+        }))
+
+      const strippedOutput = removeAllWhitespace(stdout)
+      expect(strippedOutput).toContain('Name')
     })
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR re-implements 5 legacy oclif table flags that were removed in oclif v4:
- **`--columns`**: Filter to specific columns (comma-separated, matches against headers or property keys)
- **`--csv`**: Output in CSV format with cell-level escaping
- **`--filter`**: Filter rows by `property=value` (simple `.includes()` substring matching)
- **`--sort`**: Multi-key sorting (comma-separated, ascending only, matches against headers or property keys)
- **`--extended`**: Show/hide extended columns (hidden by default)

### Changes Made
- Created shared `parseKeyValue` utility in `src/utils/` for parsing `property=value` inputs
- Added `natural-orderby` dependency to ensure CSV and table output sort identically (same library oclif uses internally)
- Overrides oclif's `filter` and `sort` flags to maintain consistency between table and csv output
- Updated `examples/table-command.ts` to include table flags

### Flag Changes from oclif v2
This implementation differs from the original oclif v2 flags in the following ways:

**`--filter` flag:**
- ❌ **Removed**: Negation support (no `-property=value` syntax)

**`--sort` flag:**
- ❌ **Removed**: Descending sort (no `-` prefix support)
- ⚠️ **Changed**: Invalid columns now throw errors (previously silently ignored)

**`--columns` flag:**
- ⚠️ **Changed**: Invalid columns now throw errors (previously silently ignored)

**Additional flags not implemented:**
- `--no-header`: Suppress header row in output
- `--no-truncate`: Disable column width truncation
- `--output`: Alternative output formats (json/yaml)

### Test Coverage
- Added 27 new unit tests to `test/unit/ux/table.test.ts` (29 total, up from 2)
- Added 6 new unit tests to `test/unit/utils/parse-key-value.test.ts`

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. Pull down this branch
2. `npm install && npm run build`
3. `npm run example table` — verify basic table output
4. `npm run example table -- --sort=name` — verify rows sorted alphabetically by name
5. `npm run example table -- --sort=status,name` — verify multi-column sorting (status first, then name)
6. `npm run example table -- --columns=Name,Status` — verify only Name and Status columns shown
7. `npm run example table -- --filter=status=Active` — verify only Active rows shown
8. `npm run example table -- --csv` — verify CSV output (comma-separated values)
9. `npm run example table -- --extended` — verify Email column shown
10. `npm run example table -- --sort=name,role --filter status=Active --csv --extended` — verify combined flags work together
11. `npm run example table -- --columns=NAME` — verify case-insensitive column matching (uppercase)
12. `npm run example table -- --columns=email` — verify matching by property key (not just header "Email")
13. `npm run example table -- --columns=Unknown` — verify error message
14. `npm run example table -- --filter=name=o` — verify substring matching (should match "John" and "Bob")

**Cleanup:**
None required.

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23125722](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cotzOYAQ/view)
