### PR TITLE
fix(ci): pass PR title via env var in pr-title-check workflow

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title follows Conventional Commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           echo "Checking PR title: $PR_TITLE"
 
           # Define allowed types


### PR DESCRIPTION
## Summary
Follow GitHub Actions best practice by reading `github.event.pull_request.title` into an `env:` variable and referencing `"$PR_TITLE"` from the shell script, rather than interpolating the `${{ ... }}` expression directly into the `run:` block. This keeps the shell script free of expression substitution and matches the pattern already used across our other repos.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: CI-only change to a workflow file. The `pr-title-check` job on this PR exercises the updated workflow end-to-end (this PR's title flows through the new `env:` path).

**Steps**:
1. Passing CI suffices.

## Screenshots (if applicable)

## Related Issues
GitHub issue: N/A
GUS work item: N/A